### PR TITLE
Multimap: Return an empty collection for unmapped keys

### DIFF
--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -18,7 +18,6 @@
 library quiver.collection;
 
 import 'dart:collection';
-import 'package:unmodifiable_collection/unmodifiable_collection.dart' as uc;
 
 part 'src/collection/bimap.dart';
 part 'src/collection/multimap.dart';

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -15,7 +15,7 @@
 part of quiver.collection;
 
 /**
- * An associative container mapping a key to multiple values.
+ * An associative container that maps a key to multiple values.
  */
 abstract class Multimap<K, V> {
   /**
@@ -120,24 +120,64 @@ abstract class Multimap<K, V> {
   bool get isNotEmpty;
 }
 
+/**
+ * Abstract base class for multimap implementations.
+ */
 abstract class _BaseMultimap<K, V> implements Multimap<K, V> {
   final Map<K, Iterable<V>> _map = new HashMap();
 
+  Iterable<V> _create();
+  void _add(Iterable<V> iterable, V value);
+  void _addAll(Iterable<V> iterable, Iterable<V> values);
+  void _clear(Iterable<V> iterable);
+  bool _remove(Iterable<V> iterable, V value);
+  Iterable<V> _wrap(Object key, Iterable<V> iterable);
+
   bool containsValue(Object value) => values.contains(value);
   bool containsKey(Object key) => _map.keys.contains(key);
-  Iterable<V> operator [](Object key) => _map[key];
 
-   void addValues(K key, Iterable<V> values) {
-     values.forEach((V value) => add(key, value));
-   }
+  Iterable<V> operator [](Object key) {
+    var values = _map[key];
+    if (values == null) {
+      values = _create();
+    }
+    return _wrap(key, values);
+  }
+
+  void add(K key, V value) {
+    _map.putIfAbsent(key, _create);
+    _add(_map[key], value);
+  }
+
+  void addValues(K key, Iterable<V> values) {
+    _map.putIfAbsent(key, _create);
+    _addAll(_map[key], values);
+  }
 
   void addAll(Multimap<K, V> other) => other.forEach((k, v) => add(k, v));
+
   bool remove(Object key, V value) {
     if (!_map.containsKey(key)) return false;
-    return (_map[key] as dynamic).remove(value);
+    bool removed = _remove(_map[key], value);
+    if (removed && _map[key].isEmpty) _map.remove(key);
+    return removed;
   }
-  Iterable<V> removeAll(Object key) => _map.remove(key);
-  void clear() => _map.clear();
+
+  Iterable<V> removeAll(Object key) {
+    var values = _map.remove(key);
+    var retValues = _create();
+    if (values != null) {
+      retValues.addAll(values);
+      values.clear();
+    }
+    return retValues;
+  }
+
+  void clear() {
+    _map.forEach((K key, V value) => _clear(value));
+    _map.clear();
+  }
+
   void forEachKey(void f(key, value)) => _map.forEach(f);
 
   void forEach(void f(key, value)) {
@@ -148,7 +188,7 @@ abstract class _BaseMultimap<K, V> implements Multimap<K, V> {
 
   Iterable<K> get keys => _map.keys;
   Iterable<V> get values => _map.values.expand((x) => x);
-  Map<K, Iterable<V>> toMap() => new uc.UnmodifiableMapView(_map);
+  Map<K, Iterable<V>> toMap() => new _WrappedMap(this);
   int get length => _map.length;
   bool get isEmpty => _map.isEmpty;
   bool get isNotEmpty => _map.isNotEmpty;
@@ -159,22 +199,17 @@ abstract class _BaseMultimap<K, V> implements Multimap<K, V> {
  * with each key.
  */
 class ListMultimap<K, V> extends _BaseMultimap<K, V> {
-  final Function _create = () => new List();
-  List<V> operator [](Object key) => _map[key];
-
-  void add(K key, V value) {
-    _map.putIfAbsent(key, _create);
-    (_map[key] as List).add(value);
-  }
-
-  void addValues(K key, Iterable<V> values) {
-    _map.putIfAbsent(key, _create);
-    (_map[key] as List).addAll(values);
-  }
-
-  List<V> removeAll(Object key) => _map.remove(key);
-
-  Map<K, List<V>> toMap() => new uc.UnmodifiableMapView(_map);
+  ListMultimap() : super();
+  List<V> _create() => new List<V>();
+  void _add(List<V> iterable, V value) => iterable.add(value);
+  void _addAll(List<V> iterable, Iterable<V> value) => iterable.addAll(value);
+  void _clear(List<V> iterable) => iterable.clear();
+  bool _remove(List<V> iterable, V value) => iterable.remove(value);
+  List<V> _wrap(Object key, List<V> iterable) =>
+      new _WrappedList(_map, key, iterable);
+  List<V> operator [](Object key) => super[key];
+  List<V> removeAll(Object key) => super.removeAll(key);
+  Map<K, List<V>> toMap() => super.toMap();
 }
 
 /**
@@ -182,20 +217,430 @@ class ListMultimap<K, V> extends _BaseMultimap<K, V> {
  * with each key.
  */
 class SetMultimap<K, V> extends _BaseMultimap<K, V> {
-  final Function _create = () => new Set();
-  Set<V> operator [](Object key) => _map[key];
+  SetMultimap() : super();
+  Set<V> _create() => new Set<V>();
+  void _add(Set<V> iterable, V value) => iterable.add(value);
+  void _addAll(Set<V> iterable, Iterable<V> value) => iterable.addAll(value);
+  void _clear(Set<V> iterable) => iterable.clear();
+  bool _remove(Set<V> iterable, V value) => iterable.remove(value);
+  Set<V> _wrap(Object key, Set<V> iterable) =>
+      new _WrappedSet(_map, key, iterable);
+  Set<V> operator [](Object key) => super[key];
+  Set<V> removeAll(Object key) => super.removeAll(key);
+  Map<K, Set<V>> toMap() => super.toMap();
+}
 
-  void add(K key, V value) {
-    _map.putIfAbsent(key, _create);
-    (_map[key] as Set).add(value);
+/**
+ * A [Map] that delegates its operations to an underlying multimap.
+ */
+class _WrappedMap<K, V> implements Map<K, V> {
+  final _BaseMultimap<K, V> _multimap;
+
+  _WrappedMap(this._multimap);
+
+  V operator [](Object key) => _multimap[key];
+
+  void operator []=(K key, V value) {
+    throw new UnsupportedError("Insert unsupported on map view");
   }
 
-  void addValues(K key, Iterable<V> values) {
-    _map.putIfAbsent(key, _create);
-    (_map[key] as Set).addAll(values);
+  void addAll(Map<K, V> other) {
+    throw new UnsupportedError("Insert unsupported on map view");
   }
 
-  Set<V> removeAll(Object key) => _map.remove(key);
+  V putIfAbsent(K key, V ifAbsent()) {
+    throw new UnsupportedError("Insert unsupported on map view");
+  }
 
-  Map<K, Set<V>> toMap() => new uc.UnmodifiableMapView(_map);
+  void clear() => _multimap.clear();
+  bool containsKey(Object key) => _multimap.containsKey(key);
+  bool containsValue(Object value) => _multimap.containsValue(value);
+  void forEach(void f(K key, V value)) => _multimap.forEach(f);
+  bool get isEmpty => _multimap.isEmpty;
+  bool get isNotEmpty => _multimap.isNotEmpty;
+  Iterable<K> get keys => _multimap.keys;
+  int get length => _multimap.length;
+  V remove(Object key) => _multimap.removeAll(key);
+  Iterable<V> get values => _multimap.values;
+}
+
+/**
+ * Iterable wrapper that syncs to an underlying map.
+ */
+class _WrappedIterable<K, V> implements Iterable<V> {
+  final K _key;
+  final Map<K, Iterable<V>> _map;
+  Iterable<V> _delegate;
+
+  _WrappedIterable(this._map, this._key, this._delegate);
+
+  _addToMap() => _map[_key] = _delegate;
+
+  /**
+   * Ensures we hold an up-to-date delegate. In the case where all mappings for
+   * _key are removed from the multimap, the Iterable referenced by _delegate is
+   * removed from the underlying map. At that point, any new addition via the
+   * multimap triggers the creation of a new Iterable, and the empty delegate
+   * we hold would be stale. As such, we check the underlying map and update
+   * our delegate when the one we hold is empty.
+   */
+  _syncDelegate() {
+    if (_delegate.isEmpty) {
+      var updated = _map[_key];
+      if (updated != null) {
+        _delegate = updated;
+      }
+    }
+  }
+
+  bool any(bool test(V element)) {
+    _syncDelegate();
+    return _delegate.any(test);
+  }
+
+  bool contains(Object element) {
+    _syncDelegate();
+    return _delegate.contains(element);
+  }
+
+  V elementAt(int index) {
+    _syncDelegate();
+    return _delegate.elementAt(index);
+  }
+
+  bool every(bool test(V element)) {
+    _syncDelegate();
+    return _delegate.every(test);
+  }
+
+  Iterable expand(Iterable f(V element)) {
+    _syncDelegate();
+    return _delegate.expand(f);
+  }
+
+  V get first {
+    _syncDelegate();
+    return _delegate.first;
+  }
+
+  V firstWhere(bool test(V element), {V orElse()}) {
+    _syncDelegate();
+    return _delegate.firstWhere(test, orElse: orElse);
+  }
+
+  fold(initialValue, combine(previousValue, V element)) {
+    _syncDelegate();
+    _delegate.fold(initialValue, combine);
+  }
+
+  void forEach(void f(V element)) {
+    _syncDelegate();
+    _delegate.forEach(f);
+  }
+
+  bool get isEmpty {
+    _syncDelegate();
+    return _delegate.isEmpty;
+  }
+
+  bool get isNotEmpty {
+    _syncDelegate();
+    return _delegate.isNotEmpty;
+  }
+
+  Iterator<V> get iterator {
+    _syncDelegate();
+    return _delegate.iterator;
+  }
+
+  String join([String separator = ""]) {
+    _syncDelegate();
+    return _delegate.join(separator);
+  }
+
+  V get last {
+    _syncDelegate();
+    return _delegate.last;
+  }
+
+  V lastWhere(bool test(V element), {V orElse()}) {
+    _syncDelegate();
+    return _delegate.lastWhere(test, orElse: orElse);
+  }
+
+  int get length {
+    _syncDelegate();
+    return _delegate.length;
+  }
+
+  Iterable map(f(V element)) {
+    _syncDelegate();
+    return _delegate.map(f);
+  }
+
+  V reduce(V combine(V value, V element)) {
+    _syncDelegate();
+    return _delegate.reduce(combine);
+  }
+
+  V get single {
+    _syncDelegate();
+    return _delegate.single;
+  }
+
+  V singleWhere(bool test(V element)) {
+    _syncDelegate();
+    return _delegate.singleWhere(test);
+  }
+
+  Iterable<V> skip(int n) {
+    _syncDelegate();
+    return _delegate.skip(n);
+  }
+
+  Iterable<V> skipWhile(bool test(V value)) {
+    _syncDelegate();
+    return _delegate.skipWhile(test);
+  }
+
+  Iterable<V> take(int n) {
+    _syncDelegate();
+    return _delegate.take(n);
+  }
+
+  Iterable<V> takeWhile(bool test(V value)) {
+    _syncDelegate();
+    return _delegate.takeWhile(test);
+  }
+
+  List<V> toList({bool growable: true}) {
+    _syncDelegate();
+    return _delegate.toList(growable: growable);
+  }
+
+  Set<V> toSet() {
+    _syncDelegate();
+    return _delegate.toSet();
+  }
+
+  Iterable<V> where(bool test(V element)) {
+    _syncDelegate();
+    return _delegate.where(test);
+  }
+}
+
+class _WrappedList<K, V> extends _WrappedIterable<K, V> implements List<V> {
+  _WrappedList(Map<K, Iterable<V>> map, K key, List<V> delegate) :
+      super(map, key, delegate);
+
+  V operator [](int index) => elementAt(index);
+
+  void operator []=(int index, V value) {
+    (_delegate as List)[index] = value;
+  }
+
+  void add(V value) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as List).add(value);
+    if (wasEmpty) _addToMap();
+  }
+
+  void addAll(Iterable<V> iterable) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as List).addAll(iterable);
+    if (wasEmpty) _addToMap();
+  }
+
+  Map<int, V> asMap() {
+    _syncDelegate();
+    return (_delegate as List).asMap();
+  }
+
+  void clear() {
+    _syncDelegate();
+    (_delegate as List).clear();
+    _map.remove(_key);
+  }
+
+  void fillRange(int start, int end, [V fillValue]) {
+    _syncDelegate();
+    (_delegate as List).fillRange(start, end, fillValue);
+  }
+
+  Iterable<V> getRange(int start, int end) {
+    _syncDelegate();
+    return (_delegate as List).getRange(start, end);
+  }
+
+  int indexOf(V element, [int start = 0]) {
+    _syncDelegate();
+    return (_delegate as List).indexOf(element, start);
+  }
+
+  void insert(int index, V element) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as List).insert(index, element);
+    if (wasEmpty) _addToMap();
+  }
+
+  void insertAll(int index, Iterable<V> iterable) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as List).insertAll(index, iterable);
+    if (wasEmpty) _addToMap();
+  }
+
+  int lastIndexOf(V element, [int start]) {
+    _syncDelegate();
+    return (_delegate as List).lastIndexOf(element, start);
+  }
+
+  void set length(int newLength) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as List).length = newLength;
+    if (wasEmpty) _addToMap();
+  }
+
+  bool remove(Object value) {
+    _syncDelegate();
+    bool removed = (_delegate as List).remove(value);
+    if (_delegate.isEmpty) _map.remove(_key);
+    return removed;
+  }
+
+  V removeAt(int index) {
+    _syncDelegate();
+    V removed = (_delegate as List).removeAt(index);
+    if (_delegate.isEmpty) _map.remove(_key);
+    return removed;
+  }
+
+  V removeLast() {
+    _syncDelegate();
+    V removed = (_delegate as List).removeLast();
+    if (_delegate.isEmpty) _map.remove(_key);
+    return removed;
+  }
+
+  void removeRange(int start, int end) {
+    _syncDelegate();
+    (_delegate as List).removeRange(start, end);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void removeWhere(bool test(V element)) {
+    _syncDelegate();
+    (_delegate as List).removeWhere(test);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void replaceRange(int start, int end, Iterable<V> iterable) {
+    _syncDelegate();
+    (_delegate as List).replaceRange(start, end, iterable);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void retainWhere(bool test(V element)) {
+    _syncDelegate();
+    (_delegate as List).retainWhere(test);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  Iterable<V> get reversed {
+    _syncDelegate();
+    return (_delegate as List).reversed;
+  }
+
+  void setAll(int index, Iterable<V> iterable) {
+    _syncDelegate();
+    (_delegate as List).setAll(index, iterable);
+  }
+
+  void setRange(int start, int end, Iterable<V> iterable, [int skipCount = 0]) {
+    _syncDelegate();
+    (_delegate as List).setRange(start, end, iterable, skipCount);
+  }
+
+  void sort([int compare(V a, V b)]) {
+    _syncDelegate();
+    (_delegate as List).sort(compare);
+  }
+
+  List<V> sublist(int start, [int end]) {
+    _syncDelegate();
+    return (_delegate as List).sublist(start, end);
+  }
+}
+
+class _WrappedSet<K, V> extends _WrappedIterable<K, V> implements Set<V> {
+  _WrappedSet(Map<K, Iterable<V>> map, K key, Iterable<V> delegate) :
+      super(map, key, delegate);
+
+  void add(V value) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as Set).add(value);
+    if (wasEmpty) _addToMap();
+  }
+
+  void addAll(Iterable<V> elements) {
+    var wasEmpty = _delegate.isEmpty;
+    (_delegate as Set).addAll(elements);
+    if (wasEmpty) _addToMap();
+  }
+
+  void clear() {
+    _syncDelegate();
+    (_delegate as Set).clear();
+    _map.remove(_key);
+  }
+
+  bool containsAll(Iterable<Object> other) {
+    _syncDelegate();
+    return (_delegate as Set).containsAll(other);
+  }
+
+  Set<V> difference(Set<V> other) {
+    _syncDelegate();
+    return (_delegate as Set).difference(other);
+  }
+
+  Set<V> intersection(Set<Object> other) {
+    _syncDelegate();
+    return (_delegate as Set).intersection(other);
+  }
+
+  bool remove(Object value) {
+    _syncDelegate();
+    bool removed = (_delegate as Set).remove(value);
+    if (_delegate.isEmpty) _map.remove(_key);
+    return removed;
+  }
+
+  void removeAll(Iterable<Object> elements) {
+    _syncDelegate();
+    (_delegate as Set).removeAll(elements);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void removeWhere(bool test(V element)) {
+    _syncDelegate();
+    (_delegate as Set).removeWhere(test);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void retainAll(Iterable<Object> elements) {
+    _syncDelegate();
+    (_delegate as Set).retainAll(elements);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  void retainWhere(bool test(V element)) {
+    _syncDelegate();
+    (_delegate as Set).retainWhere(test);
+    if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  Set<V> union(Set<V> other) {
+    _syncDelegate();
+    return (_delegate as Set).union(other);
+  }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,5 @@ environment:
   sdk: '>=0.7.2 <0.8.0'
 dependencies:
   path: '>=0.7.2 <0.8.0'
-  unmodifiable_collection: '>=0.7.2 <0.8.0'
 dev_dependencies:
   unittest: '>=0.7.2 <0.8.0'

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -49,9 +49,57 @@ void main() {
       expect(map.length, 2);
     });
 
-    test('should return null for a key that has not been added', () {
+    test('should return an empty iterable for unmapped keys', () {
       Multimap map = new ListMultimap();
-      expect(map['k1'], null);
+      expect(map['k1'], []);
+    });
+
+    test('should support adding values for unmapped keys', () {
+      ListMultimap map = new ListMultimap()
+        ..['k1'].add('v1');
+      expect(map['k1'], ['v1']);
+    });
+
+    test('should support adding multiple values for unmapped keys', () {
+      ListMultimap map = new ListMultimap()
+        ..['k1'].addAll(['v1', 'v2']);
+      expect(map['k1'], ['v1', 'v2']);
+    });
+
+    test('should support inserting values for unmapped keys', () {
+      ListMultimap map = new ListMultimap()
+        ..['k1'].insert(0, 'v1');
+      expect(map['k1'], ['v1']);
+    });
+
+    test('should support inserting multiple values for unmapped keys', () {
+      ListMultimap map = new ListMultimap()
+        ..['k1'].insertAll(0, ['v1', 'v2']);
+      expect(map['k1'], ['v1', 'v2']);
+    });
+
+    test('should support inserting multiple values for unmapped keys', () {
+      ListMultimap map = new ListMultimap()
+        ..['k1'].length = 2;
+      expect(map['k1'], [null, null]);
+    });
+
+    test('should return unmapped iterables that stay in sync on add', () {
+      ListMultimap map = new ListMultimap();
+      List values1 = map['k1'];
+      List values2 = map['k1'];
+      values1.add('v1');
+      expect(map['k1'], ['v1']);
+      expect(values2, ['v1']);
+    });
+
+    test('should return unmapped iterables that stay in sync on addAll', () {
+      ListMultimap map = new ListMultimap();
+      List values1 = map['k1'];
+      List values2 = map['k1'];
+      values1.addAll(['v1', 'v2']);
+      expect(map['k1'], ['v1', 'v2']);
+      expect(values2, ['v1', 'v2']);
     });
 
     test('should support adding duplicate values for a key', () {
@@ -172,6 +220,78 @@ void main() {
       expect(map.containsKey('k2'), true);
     });
 
+    test('should remove a key when all associated values are removed', () {
+      Multimap map = new ListMultimap()
+        ..add('k1', 'v1')
+        ..remove('k1', 'v1');
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.remove', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].remove('v1');
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeAt', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].removeAt(0);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeAt', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].removeLast();
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeRange', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].removeRange(0, 1);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeWhere', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].removeWhere((_) => true);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.replaceRange', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].replaceRange(0, 1, []);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.retainWhere', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      map['k1'].retainWhere((_) => false);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+        'via the underlying iterable.clear', () {
+      ListMultimap map = new ListMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      map['k1'].clear();
+      expect(map.containsKey('k1'), false);
+    });
+
     test('should remove all values for a key', () {
       Multimap map = new ListMultimap()
         ..add('k1', 'v1')
@@ -179,8 +299,15 @@ void main() {
         ..add('k2', 'v3');
       expect(map.removeAll('k1'), ['v1', 'v2']);
       expect(map.containsKey('k1'), false);
-      expect(map['k1'], null);
       expect(map.containsKey('k2'), true);
+    });
+
+    test('should clear underlying iterable on remove', () {
+      Multimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      List values = map['k1'];
+      expect(map.removeAll('k1'), ['v1']);
+      expect(values, []);
     });
 
     test('should clear the map', () {
@@ -190,11 +317,32 @@ void main() {
         ..add('k2', 'v3')
         ..clear();
       expect(map.isEmpty, true);
-      expect(map['k1'], null);
-      expect(map['k2'], null);
+      expect(map.containsKey('k1'), false);
+      expect(map.containsKey('k2'), false);
     });
 
-    test('should return an unmodifiable map view', () {
+    test('should clear underlying iterables on clear', () {
+      Multimap map = new ListMultimap()
+        ..add('k1', 'v1');
+      List values = map['k1'];
+      map.clear();
+      expect(values, []);
+    });
+
+    test('should not add mappings on lookup of unmapped keys', () {
+      Multimap map = new ListMultimap()
+        ..['k1'];
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should not remove mappings on clearing mapped values', () {
+      Multimap map = new ListMultimap()
+        ..add('k1', 'v1')
+        ..['v1'].clear();
+      expect(map.containsKey('k1'), true);
+    });
+
+    test('should return a map view', () {
       Multimap mmap = new ListMultimap()
         ..add('k1', 'v1')
         ..add('k1', 'v2')
@@ -203,7 +351,48 @@ void main() {
       expect(map.keys, unorderedEquals(['k1', 'k2']));
       expect(map['k1'], ['v1', 'v2']);
       expect(map['k2'], ['v3']);
-      expect(() => map['k3'] = 'v4', throws);
+    });
+
+    test('should return an empty iterable on map view unmapped key', () {
+      Map map = new ListMultimap().toMap();
+      expect(map['k1'], []);
+    });
+
+    test('should allow addition via unmapped key lookup on map view', () {
+      Multimap mmap = new ListMultimap();
+      Map map = mmap.toMap();
+      map['k1'].add('v1');
+      map['k2'].addAll(['v1', 'v2']);
+      expect(mmap['k1'], ['v1']);
+      expect(mmap['k2'], ['v1', 'v2']);
+    });
+
+    test('should reflect additions to iterables returned by map view', () {
+      Multimap mmap = new ListMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      Map map = mmap.toMap();
+      map['k1'].add('v3');
+      expect(mmap['k1'], ['v1', 'v2', 'v3']);
+    });
+
+    test('should reflect removals of keys in returned map view', () {
+      Multimap mmap = new ListMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      Map map = mmap.toMap();
+      map.remove('k1');
+      expect(mmap.containsKey('k1'), false);
+    });
+
+    test('should reflect clearing of returned map view', () {
+      Multimap mmap = new ListMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2')
+        ..add('k2', 'v3');
+      Map map = mmap.toMap();
+      map.clear();
+      expect(mmap.isEmpty, true);
     });
 
     test('should support iteration over all {key, value} pairs', () {
@@ -254,9 +443,39 @@ void main() {
       expect(map.length, 2);
     });
 
-    test('should return null for a key that has not been added', () {
+    test('should return an empty iterable for unmapped keys', () {
       Multimap map = new SetMultimap();
-      expect(map['k1'], null);
+      expect(map['k1'], []);
+    });
+
+    test('should support adding values for unmapped keys', () {
+      SetMultimap map = new SetMultimap()
+        ..['k1'].add('v1');
+      expect(map['k1'], ['v1']);
+    });
+
+    test('should support adding multiple values for unmapped keys', () {
+      SetMultimap map = new SetMultimap()
+        ..['k1'].addAll(['v1', 'v2']);
+      expect(map['k1'], unorderedEquals(['v1', 'v2']));
+    });
+
+    test('should return unmapped iterables that stay in sync on add', () {
+      SetMultimap map = new SetMultimap();
+      Set values1 = map['k1'];
+      Set values2 = map['k1'];
+      values1.add('v1');
+      expect(map['k1'], ['v1']);
+      expect(values2, ['v1']);
+    });
+
+    test('should return unmapped iterables that stay in sync on addAll', () {
+      SetMultimap map = new SetMultimap();
+      Set values1 = map['k1'];
+      Set values2 = map['k1'];
+      values1.addAll(['v1', 'v2']);
+      expect(map['k1'], unorderedEquals(['v1', 'v2']));
+      expect(values2, unorderedEquals(['v1', 'v2']));
     });
 
     test('should not support adding duplicate values for a key', () {
@@ -384,6 +603,62 @@ void main() {
       expect(map.containsKey('k2'), true);
     });
 
+    test('should remove a key when all associated values are removed', () {
+      Multimap map = new SetMultimap()
+        ..add('k1', 'v1')
+        ..remove('k1', 'v1');
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.remove', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      map['k1'].remove('v1');
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeAll', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      map['k1'].removeAll(['v1', 'v2']);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.removeWhere', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      map['k1'].removeWhere((_) => true);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.retainAll', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      map['k1'].retainAll([]);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+         'via the underlying iterable.retainWhere', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      map['k1'].retainWhere((_) => false);
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should remove a key when all associated values are removed' +
+        'via the underlying iterable.clear', () {
+      SetMultimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      map['k1'].clear();
+      expect(map.containsKey('k1'), false);
+    });
+
     test('should remove all values for a key', () {
       Multimap map = new SetMultimap()
         ..add('k1', 'v1')
@@ -391,8 +666,15 @@ void main() {
         ..add('k2', 'v3');
       expect(map.removeAll('k1'), unorderedEquals(['v1', 'v2']));
       expect(map.containsKey('k1'), false);
-      expect(map['k1'], null);
       expect(map.containsKey('k2'), true);
+    });
+
+    test('should clear underlying iterable on remove', () {
+      Multimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      Set values = map['k1'];
+      expect(map.removeAll('k1'), ['v1']);
+      expect(values, []);
     });
 
     test('should clear the map', () {
@@ -402,11 +684,32 @@ void main() {
         ..add('k2', 'v3')
         ..clear();
       expect(map.isEmpty, true);
-      expect(map['k1'], null);
-      expect(map['k2'], null);
+      expect(map.containsKey('k1'), false);
+      expect(map.containsKey('k2'), false);
     });
 
-    test('should return an unmodifiable map view', () {
+    test('should clear underlying iterables on clear', () {
+      Multimap map = new SetMultimap()
+        ..add('k1', 'v1');
+      Set values = map['k1'];
+      map.clear();
+      expect(values, []);
+    });
+
+    test('should not add mappings on lookup of unmapped keys', () {
+      Multimap map = new SetMultimap()
+        ..['k1'];
+      expect(map.containsKey('k1'), false);
+    });
+
+    test('should not remove mappings on clearing mapped values', () {
+      Multimap map = new SetMultimap()
+        ..add('k1', 'v1')
+        ..['v1'].clear();
+      expect(map.containsKey('k1'), true);
+    });
+
+    test('should return a map view', () {
       Multimap mmap = new SetMultimap()
         ..add('k1', 'v1')
         ..add('k1', 'v2')
@@ -415,7 +718,57 @@ void main() {
       expect(map.keys, unorderedEquals(['k1', 'k2']));
       expect(map['k1'], ['v1', 'v2']);
       expect(map['k2'], ['v3']);
-      expect(() => map['k3'] = 'v4', throws);
+    });
+
+    test('should return an empty iterable on map view unmapped key', () {
+      Map map = new SetMultimap().toMap();
+      expect(map['k1'], []);
+    });
+
+    test('should allow addition via unmapped key lookup on map view', () {
+      Multimap mmap = new SetMultimap();
+      Map map = mmap.toMap();
+      map['k1'].add('v1');
+      map['k2'].addAll(['v1', 'v2']);
+      expect(mmap['k1'], ['v1']);
+      expect(mmap['k2'], unorderedEquals(['v1', 'v2']));
+    });
+
+    test('should reflect additions to iterables returned by map view', () {
+      Multimap mmap = new SetMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      Map map = mmap.toMap();
+      map['k1'].add('v3');
+      expect(mmap['k1'], unorderedEquals(['v1', 'v2', 'v3']));
+    });
+
+    test('should reflect additions to iterables returned by map view', () {
+      Multimap mmap = new SetMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      Map map = mmap.toMap();
+      map['k1'].add('v3');
+      expect(mmap['k1'], unorderedEquals(['v1', 'v2', 'v3']));
+    });
+
+    test('should reflect removals of keys in returned map view', () {
+      Multimap mmap = new SetMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2');
+      Map map = mmap.toMap();
+      map.remove('k1');
+      expect(mmap.containsKey('k1'), false);
+    });
+
+    test('should reflect clearing of returned map view', () {
+      Multimap mmap = new SetMultimap()
+        ..add('k1', 'v1')
+        ..add('k1', 'v2')
+        ..add('k2', 'v3');
+      Map map = mmap.toMap();
+      map.clear();
+      expect(mmap.isEmpty, true);
     });
 
     test('should support iteration over all {key, value} pairs', () {


### PR DESCRIPTION
Updated `Multimap` (ListMultimap and SetMultimap) to return an empty Iterable when fetching unmapped keys. The returned Iterable remains consistent with the underlying multimap. This is the case whether the iterable is fetched directly from the Multimap or via the Map view returned by `toMap()`:

``` dart
ListMultimap mmap = new ListMultimap();

// Additions to map, map view reflected in returned Iterable
List values = mmap[k1];  // values == [],       map.containsKey(k1) == false
mmap.add(k1, v1);        // values == [v1],     map.containsKey(k1) == true
mmap.toMap[k1].add(v2);  // values == [v1,v2],  map.containsKey(k1) == true

// Additions to returned Iterables reflected in map, map view
values = map[k2];        // map[k2] == [],       map.containsKey(k2) == false
values.add(v1);          // map[k2] == [v1],     map.containsKey(k2) == true
mmap.toMap[k2].add(v2);  // map[k2] == [v1, v2], map.containsKey(k2) == true
```
