### PR TITLE
Add bi-directional map

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ next element.
 ## collection.dart
 
 `Multimap` is an associative collection that maps keys to collections of
-values.
+values. `BiMap` is a bi-directional map and provides an inverse view, allowing
+lookup of key by value.
 
 ## io.dart
 

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -20,6 +20,7 @@ library quiver.collection;
 import 'dart:collection';
 import 'package:unmodifiable_collection/unmodifiable_collection.dart' as uc;
 
+part 'src/collection/bimap.dart';
 part 'src/collection/multimap.dart';
 part 'src/collection/delegates/iterable.dart';
 part 'src/collection/delegates/list.dart';

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -1,0 +1,114 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.collection;
+
+/**
+ * A bi-directional map whose key-value pairs form a one-to-one correspondence.
+ * BiMaps support an `inverse` property which gives access to an inverted view
+ * of the map, such that there is a mapping (v, k) for each pair (k, v) in the
+ * original map. Since a one-to-one key-value invariant applies, it is an error
+ * to insert duplicate values into this map. It is also an error to insert null
+ * keys or values into this map.
+ */
+abstract class BiMap<K, V> implements Map<K, V> {
+  /**
+   * Creates a BiMap instance with the default implementation.
+   */
+  factory BiMap() => new HashBiMap();
+
+  /**
+   * Adds an association between key and value.
+   *
+   * Throws [ArgumentError] if an association involving [value] exists in the
+   * map; otherwise, the association is inserted, overwriting any existing
+   * association for the key.
+   */
+  void operator []=(K key, V value);
+
+  /**
+   * Replaces any existing associations(s) involving key and value.
+   *
+   * If an association involving [key] or [value] exists in the map, it is
+   * removed.
+   */
+  void replace(K key, V value);
+
+  /**
+   * Returns the inverse of this map, with key-value pairs (v, k) for each
+   * pair (k, v) in this map.
+   */
+  BiMap<V, K> get inverse;
+}
+
+/**
+ * A hash-table based implementation of BiMap.
+ */
+class HashBiMap<K, V> implements BiMap<K, V> {
+  final Map<K, V> _map;
+  final Map<V, K> _inverse;
+  BiMap<V, K> _cached;
+
+  HashBiMap() : this._from(new HashMap(), new HashMap());
+  HashBiMap._from(this._map, this._inverse);
+
+  V operator [](Object key) => _map[key];
+  void operator []=(K key, V value) { _add(key, value, false); }
+  void replace(K key, V value) { _add(key, value, true); }
+  void addAll(Map<K, V> other) => other.forEach((k, v) => _add(k, v, false));
+  bool containsKey(Object key) => _map.containsKey(key);
+  bool containsValue(Object value) => _inverse.containsKey(value);
+  void forEach(void f(K key, V value)) => _map.forEach(f);
+  bool get isEmpty => _map.isEmpty;
+  bool get isNotEmpty => _map.isNotEmpty;
+  Iterable<K> get keys => _map.keys;
+  int get length => _map.length;
+  Iterable<V> get values => _inverse.keys;
+
+  BiMap<V, K> get inverse {
+    if (_cached == null) {
+      _cached = new HashBiMap._from(_inverse, _map);
+    }
+    return _cached;
+  }
+
+  V putIfAbsent(K key, V ifAbsent()) {
+    if (!_map.containsKey(key)) _add(key, ifAbsent(), false);
+  }
+
+  V remove(Object key) {
+    _inverse.remove(_map[key]);
+    _map.remove(key);
+  }
+
+  void clear() {
+    _map.clear();
+    _inverse.clear();
+  }
+
+  V _add(K key, V value, bool replace) {
+    if (key == null) throw new ArgumentError("null key");
+    if (value == null) throw new ArgumentError("null value");
+    var oldValue = _map[key];
+    if (oldValue == value) return;
+    if (inverse.containsKey(value)) {
+      if (!replace) throw new ArgumentError("Mapping for $value exists");
+      _map.remove(_inverse[value]);
+    }
+    _inverse.remove(oldValue);
+    _map[key] = value;
+    _inverse[value] = key;
+  }
+}
+

--- a/test/collection/all_tests.dart
+++ b/test/collection/all_tests.dart
@@ -14,6 +14,7 @@
 
 library quiver.collection.all_tests;
 
+import 'bimap_test.dart' as bimap;
 import 'multimap_test.dart' as multimap;
 import 'delegates/iterable_test.dart' as iterable;
 import 'delegates/list_test.dart' as list;
@@ -22,6 +23,7 @@ import 'delegates/queue_test.dart' as queue;
 import 'delegates/set_test.dart' as set;
 
 main() {
+  bimap.main();
   multimap.main();
   iterable.main();
   list.main();

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -1,0 +1,339 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.collection.bimap_test;
+
+import 'package:quiver/collection.dart';
+import 'package:unittest/unittest.dart';
+
+main() {
+  group('BiMap', () {
+    test('should construct a HashBiMap', () {
+      expect(new BiMap() is HashBiMap, true);
+    });
+  });
+
+  group('HashBiMap', () {
+    BiMap<String, int> map;
+    String k1 = 'k1', k2 = 'k2', k3 = 'k3';
+    int v1 = 1, v2 = 2, v3 = 3;
+
+    setUp(() {
+      map = new HashBiMap();
+    });
+
+    test('should initialize empty', () {
+      expect(map.isEmpty, true);
+      expect(map.isNotEmpty, false);
+      expect(map.inverse.isEmpty, true);
+      expect(map.inverse.isNotEmpty, false);
+    });
+
+    test('should throw when adding a null key or value', () {
+      expect(() => map[null] = v1, throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map[k1] = null, throwsA(new isInstanceOf<ArgumentError>()));
+    });
+
+    test('should throw when adding a null key or value via its inverse', () {
+      expect(() => map.inverse[null] = v1,
+             throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map.inverse[k1] = null,
+             throwsA(new isInstanceOf<ArgumentError>()));
+    });
+
+    test('should not be empty after adding a mapping', () {
+      map[k1] = v1;
+      expect(map.isEmpty, false);
+      expect(map.isNotEmpty, true);
+      expect(map.inverse.isEmpty, false);
+      expect(map.inverse.isNotEmpty, true);
+    });
+
+    test('should not be empty after adding a mapping via its inverse', () {
+      map.inverse[v1] = k1;
+      expect(map.isEmpty, false);
+      expect(map.isNotEmpty, true);
+      expect(map.inverse.isEmpty, false);
+      expect(map.inverse.isNotEmpty, true);
+    });
+
+    test('should contain added mappings', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      expect(map[k1], v1);
+      expect(map[k2], v2);
+      expect(map.inverse[v1], k1);
+      expect(map.inverse[v2], k2);
+    });
+
+    test('should contain mappings added via its invese', () {
+      map.inverse[v1] = k1;
+      map.inverse[v2] = k2;
+      expect(map[k1], v1);
+      expect(map[k2], v2);
+      expect(map.inverse[v1], k1);
+      expect(map.inverse[v2], k2);
+    });
+
+    test('should allow overwriting existing keys', () {
+      map[k1] = v1;
+      map[k1] = v2;
+      expect(map[k1], v2);
+      expect(map.inverse.containsKey(v1), false);
+      expect(map.inverse[v2], k1);
+    });
+
+    test('should allow overwriting existing keys via its inverse', () {
+      map.inverse[v1] = k1;
+      map.inverse[v1] = k2;
+      expect(map[k2], v1);
+      expect(map.inverse.containsKey(v2), false);
+      expect(map.inverse[v1], k2);
+    });
+
+    test('should allow overwriting existing key-value pairs', () {
+      map[k1] = v1;
+      map[k1] = v1;
+      expect(map[k1], v1);
+      expect(map.inverse.containsKey(v1), true);
+      expect(map.inverse[v1], k1);
+    });
+
+    test('should allow overwriting existing key-value pairs via its inverse', () {
+      map.inverse[v1] = k1;
+      map.inverse[v1] = k1;
+      expect(map[k1], v1);
+      expect(map.inverse.containsKey(v1), true);
+      expect(map.inverse[v1], k1);
+    });
+
+    test('should throw on overwriting unmapped keys with a mapped value', () {
+      map[k1] = v1;
+      expect(() => map[k2] = v1, throwsA(new isInstanceOf<ArgumentError>()));
+      expect(map.containsKey(k2), false);
+      expect(map.inverse.containsValue(k2), false);
+    });
+
+    test('should throw on overwriting unmapped keys with a mapped value via inverse', () {
+      map[k1] = v1;
+      expect(() => map.inverse[v2] = k1,
+             throwsA(new isInstanceOf<ArgumentError>()));
+      expect(map.containsValue(v2), false);
+      expect(map.inverse.containsKey(v2), false);
+    });
+
+    test('should allow force-adding unmapped keys with a mapped value', () {
+      map[k1] = v1;
+      map.replace(k2, v1);
+      expect(map[k2], v1);
+      expect(map.containsKey(k1), false);
+      expect(map.inverse[v1], k2);
+      expect(map.inverse.containsValue(k1), false);
+    });
+
+    test('should allow force-adding unmapped keys with a mapped value via inverse', () {
+      map.inverse[v1] = k1;
+      map.inverse.replace(v2, k1);
+      expect(map[k1], v2);
+      expect(map.containsValue(v1), false);
+      expect(map.inverse[v2], k1);
+      expect(map.inverse.containsKey(v1), false);
+    });
+
+    test('should not contain removed mappings', () {
+      map[k1] = v1;
+      map.remove(k1);
+      expect(map.containsKey(k1), false);
+      expect(map.inverse.containsKey(v1), false);
+    });
+
+    test('should not contain mappings removed from its inverse', () {
+      map[k1] = v1;
+      map.inverse.remove(v1);
+      expect(map.containsKey(k1), false);
+      expect(map.inverse.containsKey(v1), false);
+    });
+
+    test('should be empty after clear', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      map.clear();
+      expect(map.isEmpty, true);
+      expect(map.inverse.isEmpty, true);
+    });
+
+    test('should be empty after inverse.clear', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      map.inverse.clear();
+      expect(map.isEmpty, true);
+      expect(map.inverse.isEmpty, true);
+    });
+
+    test('should contain mapped keys', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      expect(map.containsKey(k1), true);
+      expect(map.containsKey(k2), true);
+      expect(map.keys, unorderedEquals([k1, k2]));
+      expect(map.inverse.containsKey(v1), true);
+      expect(map.inverse.containsKey(v2), true);
+      expect(map.inverse.keys, unorderedEquals([v1, v2]));
+    });
+
+    test('should contain keys mapped via its inverse', () {
+      map.inverse[v1] = k1;
+      map.inverse[v2] = k2;
+      expect(map.containsKey(k1), true);
+      expect(map.containsKey(k2), true);
+      expect(map.keys, unorderedEquals([k1, k2]));
+      expect(map.inverse.containsKey(v1), true);
+      expect(map.inverse.containsKey(v2), true);
+      expect(map.inverse.keys, unorderedEquals([v1, v2]));
+    });
+
+    test('should contain mapped values', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      expect(map.containsValue(v1), true);
+      expect(map.containsValue(v2), true);
+      expect(map.values, unorderedEquals([v1, v2]));
+      expect(map.inverse.containsValue(k1), true);
+      expect(map.inverse.containsValue(k2), true);
+      expect(map.inverse.values, unorderedEquals([k1, k2]));
+    });
+
+    test('should contain values mapped via its inverse', () {
+      map.inverse[v1] = k1;
+      map.inverse[v2] = k2;
+      expect(map.containsValue(v1), true);
+      expect(map.containsValue(v2), true);
+      expect(map.values, unorderedEquals([v1, v2]));
+      expect(map.inverse.containsValue(k1), true);
+      expect(map.inverse.containsValue(k2), true);
+      expect(map.inverse.values, unorderedEquals([k1, k2]));
+    });
+
+    test('should add mappings via putIfAbsent if absent', () {
+      map.putIfAbsent(k1, () => v1);
+      expect(map[k1], v1);
+      expect(map.inverse[v1], k1);
+    });
+
+    test('should add mappings via inverse.putIfAbsent if absent', () {
+      map.inverse.putIfAbsent(v1, () => k1);
+      expect(map[k1], v1);
+      expect(map.inverse[v1], k1);
+    });
+
+    test('should not add mappings via putIfAbsent if present', () {
+      map[k1] = v1;
+      map.putIfAbsent(k1, () => v2);
+      expect(map[k1], v1);
+      expect(map.inverse[v1], k1);
+      expect(map.inverse.containsKey(v2), false);
+    });
+
+    test('should not add mappings via inverse.putIfAbsent if present', () {
+      map[k1] = v1;
+      map.inverse.putIfAbsent(v1, () => k2);
+      expect(map[k1], v1);
+      expect(map.containsKey(k2), false);
+      expect(map.inverse[v1], k1);
+    });
+
+    test('should contain mappings added from another map', () {
+      map.addAll({
+        k1: v1,
+        k2: v2,
+        k3: v3
+      });
+      expect(map[k1], v1);
+      expect(map[k2], v2);
+      expect(map[k3], v3);
+      expect(map.inverse[v1], k1);
+      expect(map.inverse[v2], k2);
+      expect(map.inverse[v3], k3);
+    });
+
+    test('should contain mappings added via its inverse from another map', () {
+      map.inverse.addAll({
+        v1: k1,
+        v2: k2,
+        v3: k3
+      });
+      expect(map[k1], v1);
+      expect(map[k2], v2);
+      expect(map[k3], v3);
+      expect(map.inverse[v1], k1);
+      expect(map.inverse[v2], k2);
+      expect(map.inverse[v3], k3);
+    });
+
+    test('should throw on adding from another map with duplicate values', () {
+      expect(() => map.addAll({
+        k1: v1,
+        k2: v2,
+        k3: v2
+      }), throwsA(new isInstanceOf<ArgumentError>()));
+    });
+
+    test('should throw on adding from another map with duplicate values via inverse', () {
+      expect(() => map.inverse.addAll({
+        v1: k1,
+        v2: k2,
+        v3: k2
+      }), throwsA(new isInstanceOf<ArgumentError>()));
+    });
+
+    test('should return the number of key-value pairs as its length', () {
+      expect(map.length, 0);
+      map[k1] = v1;
+      expect(map.length, 1);
+      map[k1] = v2;
+      expect(map.length, 1);
+      map.replace(k2, v2);
+      expect(map.length, 1);
+      map[k1] = v1;
+      expect(map.length, 2);
+    });
+
+    test('should iterate over all pairs via forEach', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      var keys = [];
+      var values = [];
+      map.forEach((k, v) {
+        keys.add(k);
+        values.add(v);
+      });
+      expect(keys, unorderedEquals([k1, k2]));
+      expect(values, unorderedEquals([v1, v2]));
+    });
+
+    test('should iterate over all pairs via forEach of its inverse', () {
+      map[k1] = v1;
+      map[k2] = v2;
+      var keys = [];
+      var values = [];
+      map.inverse.forEach((k, v) {
+        keys.add(k);
+        values.add(v);
+      });
+      expect(keys, unorderedEquals([v1, v2]));
+      expect(values, unorderedEquals([k1, k2]));
+    });
+  });
+}
+


### PR DESCRIPTION
Bi-map supports a one-to-one key mapping with a (synchronized) inverse view.

``` dart
BiMap map = new BiMap();
map[k1] = v1;
assert(map.inverse[v1] == k1);

map.inverse[v1] = k2;  // eliminates k1 mapping
assert(map[k2] == v1);
assert(!map.containsKey(k1));
```
