### PR TITLE
Add test to reflectively invoking method with named arguments

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,9 +9,9 @@ description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 documentation: http://google.github.io/quiver-dart/docs/
 environment:
-  sdk: '>=0.7.1 <0.8.0'
+  sdk: '>=0.7.2 <0.8.0'
 dependencies:
-  path: '>=0.7.1 <0.8.0'
-  unmodifiable_collection: '>=0.7.1 <0.8.0'
+  path: '>=0.7.2 <0.8.0'
+  unmodifiable_collection: '>=0.7.2 <0.8.0'
 dev_dependencies:
-  unittest: '>=0.7.1 <0.8.0'
+  unittest: '>=0.7.2 <0.8.0'

--- a/test/mirrors_test.dart
+++ b/test/mirrors_test.dart
@@ -82,12 +82,12 @@ main() {
       expect(method(3), 5);
     });
 
-    test('should throw with named arguments', () {
+    test('should be callable with named arguments', () {
       // this test will fail when named argument support is added
       var i = [1, 2];
       var mirror = reflect(i);
       var method = new Method(mirror, const Symbol('toList'));
-      expect(() => method(growable: false), throws);
+      expect(method(growable: false), [1, 2]);
     });
 
   });


### PR DESCRIPTION
Named args are now supported on reflective method invocation in the VM.

Commit:
https://code.google.com/p/dart/source/detail?r=27134

Review:
https://codereview.chromium.org/23604003
