### PR TITLE
Removed upper bounds on SDK dependencies

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,8 @@ description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 documentation: http://google.github.io/quiver-dart/docs/
 environment:
-  sdk: '>=0.7.2 <0.8.0'
+  sdk: '>=0.7.2'
 dependencies:
-  path: '>=0.7.2 <0.8.0'
+  path: '>=0.7.2'
 dev_dependencies:
-  unittest: '>=0.7.2 <0.8.0'
+  unittest: '>=0.7.2'


### PR DESCRIPTION
Address issue #38 (upper bound on SDK constraint is not good practice) 
