### PR TITLE
Implement Glob.matchAsPrefix()

### DIFF
--- a/lib/src/pattern/glob.dart
+++ b/lib/src/pattern/glob.dart
@@ -37,9 +37,7 @@ class Glob implements Pattern {
 
   Iterable<Match> allMatches(String str) => regex.allMatches(str);
 
-  Match matchAsPrefix(String string, [int start = 0]) {
-    return regex.matchAsPrefix(string, start);
-  }
+  Match matchAsPrefix(String string, [int start = 0]) => regex.matchAsPrefix(string, start);
 
   bool hasMatch(String str) => regex.hasMatch(str);
 

--- a/test/pattern/glob_test.dart
+++ b/test/pattern/glob_test.dart
@@ -48,10 +48,14 @@ expectGlob(String pattern, { List<String> matches, List<String> nonMatches}) {
   for (var str in matches) {
     expect(glob.hasMatch(str), true);
     expect(glob.allMatches(str).map((m) => m.input), [str]);
+    var match = glob.matchAsPrefix(str);
+    expect(match.start, 0);
+    expect(match.end, str.length);
   }
   for (var str in nonMatches) {
     expect(glob.hasMatch(str), false);
     var m = new List.from(glob.allMatches(str));
     expect(m.length, 0);
+    expect(glob.matchAsPrefix(str), null);
   }
 }


### PR DESCRIPTION
This also allows matchesFull() to be used with Glob patterns.
