### PR TITLE
Added iterables.groupby implementation

### DIFF
--- a/lib/iterables.dart
+++ b/lib/iterables.dart
@@ -20,6 +20,7 @@ part 'src/iterables/concat.dart';
 part 'src/iterables/count.dart';
 part 'src/iterables/cycle.dart';
 part 'src/iterables/enumerate.dart';
+part 'src/iterables/groupby.dart';
 part 'src/iterables/infinite_iterable.dart';
 part 'src/iterables/merge.dart';
 part 'src/iterables/min_max.dart';

--- a/lib/src/iterables/groupby.dart
+++ b/lib/src/iterables/groupby.dart
@@ -1,0 +1,83 @@
+part of quiver.iterables;
+
+/**
+ * Returns an [Iterable] of [Group]s, where each element
+ * contains all elements of the [Iterable] which agree on the
+ * values returned by the provided key function.
+ *
+ * The behaviour is undefined if the key function returns different
+ * values when passed the same element twice.
+ */
+Iterable<Group> groupBy(Iterable iterable, {key(var k)}) {
+  if (key == null)
+    key = (x) => x;
+  return new _GroupBy(iterable, key);
+}
+
+/**
+ * A group is an [Iterable] where all elements match on a given key.s
+ */
+class Group<K,E> extends IterableBase<E> {
+  final K key;
+  final Iterable<E> values;
+
+  Group(this.key, this.values);
+  Iterator<E> get iterator => values.iterator;
+  String toString() => "($key: $values)";
+}
+
+typedef K _KeyFunc<K,E>(E element);
+
+class _GroupBy<K,E> extends IterableBase<Group<K,E>> {
+  final Iterable _iterable;
+  final _KeyFunc<K,E> _keyFunc;
+
+  _GroupBy(Iterable<E> this._iterable, K this._keyFunc(E value));
+
+  Iterator<Group<K,E>> get iterator =>
+      new _GroupByIterator(_iterable, _keyFunc);
+}
+
+class _Sentinel { const _Sentinel(); }
+
+class _GroupByIterator<K,E> implements Iterator<Group<K,E>> {
+  /**
+   * Use a sentinel value instead of checking for a null key to end
+   * the iteration. This allows key functions to return `null`.
+   */
+  static const _sentinel = const _Sentinel();
+
+  Iterator<K> _keyIterator;
+  Iterable<E> _valueIterable;
+  _KeyFunc<K,E> _keyFunc;
+
+  Set<K> _seenKeys;
+  Group<K,E> _current;
+
+  _GroupByIterator(Iterable<E> iterable, K keyFunc(E item)) :
+    _keyIterator = iterable.map(keyFunc).iterator,
+    _keyFunc = keyFunc,
+    _valueIterable = iterable,
+    _seenKeys = new Set<K>();
+
+  Group<K,E> get current => _current;
+
+  bool moveNext() {
+    var key = _sentinel;
+    var i = 0;
+    while(_keyIterator.moveNext()) {
+      if (!_seenKeys.contains(_keyIterator.current)) {
+        key = _keyIterator.current;
+        break;
+      }
+    }
+    if (key == _sentinel) {
+      _current = null;
+      return false;
+    }
+
+    _seenKeys.add(key);
+    _current = new Group<K,E>(key, _valueIterable.where((v) => _keyFunc(v) == key));
+    return true;
+  }
+}

--- a/test/iterables/all_tests.dart
+++ b/test/iterables/all_tests.dart
@@ -18,6 +18,7 @@ import 'concat_test.dart' as concat;
 import 'count_test.dart' as count;
 import 'cycle_test.dart' as cycle;
 import 'enumerate_test.dart' as enumerate;
+import 'groupby_test.dart' as groupby;
 import 'merge_test.dart' as merge;
 import 'range_test.dart' as range;
 import 'zip_test.dart' as zip;
@@ -27,6 +28,7 @@ main() {
   count.main();
   cycle.main();
   enumerate.main();
+  groupby.main();
   merge.main();
   range.main();
   zip.main();

--- a/test/iterables/groupby_test.dart
+++ b/test/iterables/groupby_test.dart
@@ -1,0 +1,34 @@
+library quiver.iterables.groupby_test;
+
+import 'package:unittest/unittest.dart';
+import 'package:quiver/iterables.dart';
+
+main() {
+  group('groupBy', () {
+    test("should ge empty given an empty iterable", () {
+      expect(groupBy([]), []);
+    });
+    test("should group by identity if no key function is provided", () {
+      expect(groupBy([1,2,2,4,4,6,6,6]),
+             [ new Group(1, [1]),
+               new Group(2, [2,2]),
+               new Group(4, [4,4]),
+               new Group(6, [6,6,6])
+             ]);
+    });
+    test("should group values according to the key function", () {
+      expect(groupBy(count().take(500), key: (x) => x % 2 == 0),
+             [ new Group(0, range(0, 500, 2)),
+               new Group(1, range(1, 500, 2))
+             ]);
+    });
+
+    test("should group values where the key function returns null", () {
+      expect(groupBy(count().take(500), key: (x) => (x == 40) ? null : true),
+             [ new Group(true, count().take(500).where((x) => x != 40)),
+               new Group(null, [40])
+             ]);
+    });
+  });
+}
+


### PR DESCRIPTION
A new and improved implementation of groupby, to replace the one in the PR I just closed. No longer uses tuples
