### PR TITLE
add deprecated annotation to trimLeft,trimRight,padLeft,PadRight

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,10 +173,6 @@ supporting a number of use-cases, including:
   * Tailing: `loop('/path/to/some/file.txt', -3) => 'txt'`
   * Reversing: `loop('top', 3, 0) => 'pot'`
 
-`padLeft`, `padRight`, and `center` pad strings to a given width.
-
-`trimLeft` and `trimRight` remove leading and trailing whitespace.
-
 [quiver.strings]: http://google.github.io/quiver-dart/#quiver/quiver-strings
 
 ## [quiver.time][]

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -120,6 +120,7 @@ void _repeat(StringBuffer sink, String s, int times) {
  * Returns [input] if `input.length` is equal to or greater than width. [input]
  * can be `null` and is treated as an empty string.
  */
+@deprecated
 String padLeft(String input, int width, String fill) {
   if (fill == null || fill.length == 0) {
     throw new ArgumentError('fill cannot be null or empty');
@@ -138,6 +139,7 @@ String padLeft(String input, int width, String fill) {
  * Returns [input] if `input.length` is equal to or greater than width. [input]
  * can be `null` and is treated as an empty string.
  */
+@deprecated
 String padRight(String input, int width, String fill) {
   if (fill == null || fill.length == 0) {
     throw new ArgumentError('fill cannot be null or empty');
@@ -154,6 +156,7 @@ String padRight(String input, int width, String fill) {
  *
  * Whitespace is defined to be the same as [String.trim].
  */
+@deprecated
 String trimLeft(String input) {
   int i = 0;
   for (var rune in input.runes) {
@@ -171,6 +174,7 @@ String trimLeft(String input) {
  *
  * Whitespace is defined to be the same as [String.trim].
  */
+@deprecated
 String trimRight(String input) {
   int i = 0;
   int lastNonWhitespace = -1;


### PR DESCRIPTION
Due to the release of dart version 1.3, dart support padLeft, padRight, trimLeft, trimRight by itself.

review @justinfagnani
