### PR TITLE
Simple MinHeap implementation + heapSort

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,8 @@ lookup of key by value.
 `TreeSet` is a balanced binary tree that offers a bidirectional iterator,
 the ability to iterate from an arbitrary anchor, and 'nearest' search.
 
-`MinHeap` is a minimum-heap that support linear bulk insertions and logarithmic minimum removals, and serves as a basis for `heapSort`.
+`MinHeap` is a minimum-heap that supports linear bulk insertions, logarithmic
+single insertions and logarithmic minimum removals (serves as a basis for `heapSort`)
 
 [quiver.collection]: http://google.github.io/quiver-dart/#quiver/quiver-collection
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ lookup of key by value.
 `TreeSet` is a balanced binary tree that offers a bidirectional iterator,
 the ability to iterate from an arbitrary anchor, and 'nearest' search.
 
+`MinHeap` is a minimum-heap that support linear bulk insertions and logarithmic minimum removals, and serves as a basis for `heapSort`.
+
 [quiver.collection]: http://google.github.io/quiver-dart/#quiver/quiver-collection
 
 ## [quiver.core][]

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -21,6 +21,7 @@ import 'dart:collection';
 import 'dart:math';
 
 part 'src/collection/bimap.dart';
+part 'src/collection/heap.dart';
 part 'src/collection/multimap.dart';
 part 'src/collection/treeset.dart';
 part 'src/collection/delegates/iterable.dart';

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -1,0 +1,154 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.collection;
+
+/**
+ * Minimum heap.
+ */
+abstract class MinHeap<V> {
+  Comparator<V> comparator;
+
+  factory MinHeap({Comparator<V> comparator: Comparable.compare}) =>
+      new ListMinHeap(comparator: comparator);
+
+  MinHeap._(this.comparator);
+
+  bool get isEmpty;
+  bool get isNotEmpty;
+  int get length;
+
+  void add(V value);
+  void addAll(Iterable<V> values);
+  V min();
+  V removeMin();
+}
+
+List heapSort(List items, {Comparator comparator: Comparable.compare}) {
+  var heap = new MinHeap(comparator: comparator)..addAll(items);
+  var n = items.length;
+  var result = new List(n); // Avoid growing the list needlessly.
+  for (int i = 0; i < n; i++) {
+    assert(heap.isNotEmpty);
+    result[i] = heap.removeMin();
+  }
+  assert(heap.isEmpty);
+  return result;
+}
+
+class ListMinHeap<V> extends MinHeap<V> {
+  final List<V> _values = [];
+
+  ListMinHeap({Comparator<V> comparator: Comparable.compare}) : super._(comparator);
+  
+  @override bool get isEmpty => _values.isEmpty;
+  @override bool get isNotEmpty => _values.isNotEmpty;
+  @override int get length => _values.length;
+    
+  @override V min() {
+    if (_values.isEmpty) {
+      throw new Exception("Heap is empty!");
+    }
+    return _values[0];
+  }
+
+  @override V removeMin() {
+    var value = min();
+    var last = _values.removeLast();
+    if (_values.isNotEmpty) {
+      _values[0] = last;
+      _bubbleDown(0);
+    }
+    return value;
+  }
+
+  @override void add(V value) {
+    var values = _values;
+    var index = values.length;
+    values.add(value);
+    _bubbleUp(index);
+  }
+  
+  @override void addAll(Iterable<V> values) {
+    if (values.isNotEmpty) {
+      _values.addAll(values);
+      for (var i = (_values.length / 2).floor(); i >= 0; i--) {
+        _bubbleDown(i);
+      }
+    }
+  }
+
+  _bubbleUp(int i) {
+    var values = _values;
+    while (i > 0) {
+      var j = i >> 1;
+      if (comparator(values[j], values[i]) < 0) {
+        return;
+      }
+      _swap(j, i);
+      i = j;
+    }
+  }
+
+  /// A.k.a heapify.
+  _bubbleDown(int i) {
+    var values = _values;
+    var length = values.length;
+    var halfLength = (length / 2).floor();
+    while (i < halfLength) {
+      var value = values[i];
+      var offset = i * 2;
+      var left = offset + 1;
+      var right = offset + 2;
+      if (left >= length) {
+        // End case: child1 and child2 do not exist.
+        return;
+      }
+      var leftValue = values[left];
+      var moreThanChild1 = comparator(value, leftValue) > 0;
+      var j;
+      if (right >= length) {
+        // End case: child2 does not exist.
+        if (moreThanChild1) {
+          j = left;
+        }
+      } else {
+        var rightValue = values[right];
+        if (moreThanChild1) {
+          // value > leftValue
+          j = comparator(leftValue, rightValue) < 0 ? left : right;
+        } else {
+          // value <= leftValue
+          var moreThanChild2 = comparator(value, rightValue) > 0;
+          if (moreThanChild2) {
+            // rightValue < value <= leftValue
+            j = right;
+          }
+        }
+      }
+      if (j == null) {
+        // value < leftValue && value < rightValue
+        return;
+      }
+      _swap(i, j);
+      i = j;
+    }
+  }
+  
+  _swap(int i, int j) {
+    var tmp = _values[i];
+    _values[i] = _values[j];
+    _values[j] = tmp;
+  }
+}

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -29,23 +29,50 @@ abstract class MinHeap<V> {
   bool get isNotEmpty;
   int get length;
 
+  /// Add a value to the heap (complexity is `O(log(n))`, where n is [length]).
   void add(V value);
+
+  /**
+   * Add values to the heap.
+   * 
+   * This is the preferred way of addind multiple values to the heap: it has
+   * a complexity of `O(n)` (where n is the final length of the heap), whereas
+   * calling [add] repeatedly has a complexity of `O(n * log(n))`.
+   */
   void addAll(Iterable<V> values);
+
+  /**
+   * Returns the smallest value, or null if [isEmpty].
+   * 
+   * This has a constant-time complexity.
+   */
   V min();
+  
+  /**
+   * Removes the smallest value and returns it, or returns null if [isEmpty].
+   * 
+   * This has a complexity of `O(log(n))`, where n is [length]
+   * (assuming [List.removeLast] has a constant-time complexity).
+   */
   V removeMin();
+  
+  /**
+   * Removes all the values using [removeMin] and returns a list of sorted values.
+   * 
+   * This has a complexity of `O(n * log(n))`, where n is [length]
+   * (assuming [List.removeLast] has a constant-time complexity).
+   */
+  List<V> removeAll();
 }
 
-List heapSort(List items, {Comparator comparator: Comparable.compare}) {
-  var heap = new MinHeap(comparator: comparator)..addAll(items);
-  var n = items.length;
-  var result = new List(n); // Avoid growing the list needlessly.
-  for (int i = 0; i < n; i++) {
-    assert(heap.isNotEmpty);
-    result[i] = heap.removeMin();
-  }
-  assert(heap.isEmpty);
-  return result;
-}
+/**
+ * Sort items with a [MinHeap] using their natural ordering
+ * (if they extend [Comparable]) or the provided comparator.
+ * 
+ * This has a complexity of `O(n * log(n))` where n is the number of items.
+ */
+List heapSort(Iterable items, {Comparator comparator: Comparable.compare}) =>
+    (new MinHeap(comparator: comparator)..addAll(items)).removeAll();
 
 class ListMinHeap<V> extends MinHeap<V> {
   final List<V> _values = [];
@@ -56,23 +83,36 @@ class ListMinHeap<V> extends MinHeap<V> {
   @override bool get isNotEmpty => _values.isNotEmpty;
   @override int get length => _values.length;
     
-  @override V min() {
-    if (_values.isEmpty) {
-      throw new Exception("Heap is empty!");
-    }
-    return _values[0];
-  }
+  @override V min() => _values.isEmpty ? null : _values.first;
 
   @override V removeMin() {
-    var value = min();
-    var last = _values.removeLast();
-    if (_values.isNotEmpty) {
-      _values[0] = last;
-      _bubbleDown(0);
+    if (_values.isEmpty) {
+      return null;
+    } else {
+      var value = min();
+      var last = _values.removeLast();
+      if (_values.isNotEmpty) {
+        _values[0] = last;
+        _bubbleDown(0);
+      }
+      return value;
     }
-    return value;
+  }
+  
+  /**
+   * Removes all the values using [removeMin] and returns a list of sorted values.
+   */ 
+  List<V> removeAll() {
+    var n = length;
+    var result = new List(n); // Avoid growing the list needlessly.
+    for (int i = 0; i < n; i++) {
+      assert(isNotEmpty);
+      result[i] = removeMin();
+    }
+    return result;
   }
 
+  /// Logarithmic-time single-add.
   @override void add(V value) {
     var values = _values;
     var index = values.length;
@@ -80,6 +120,7 @@ class ListMinHeap<V> extends MinHeap<V> {
     _bubbleUp(index);
   }
   
+  /// Linear-time bulk-add.
   @override void addAll(Iterable<V> values) {
     if (values.isNotEmpty) {
       _values.addAll(values);

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -16,8 +16,9 @@ part of quiver.collection;
 
 /**
  * Minimum heap: data structure containing comparable values, optimized to do
- * bulk insertions in linear time, single insertions in amortized logarithmic
- * time, and continuous removals of their minimum value in logarithmic time.
+ * bulk insertions in linear time of the final length of the heap,
+ * single insertions in amortized logarithmic time, and continuous removals of
+ * its minimum value in logarithmic time.
  *
  * Uses the elements' natural ordering or a user-provided comparator.
  */

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -156,7 +156,7 @@ class ListMinHeap<V> extends MinHeap<V> {
   _bubbleUp(int i) {
     var values = _values;
     while (i > 0) {
-      var j = i >> 1;
+      var j = i ~/ 2;
       if (comparator(values[j], values[i]) < 0) {
         return;
       }

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -16,7 +16,7 @@ part of quiver.collection;
 
 /**
  * Minimum heap: data structure optimized to add comparable values in linear
- * time and continuously removing their minimum value in logarithmic time.
+ * time and continuously remove their minimum value in logarithmic time.
  * 
  * Uses the elements' natural ordering or a user-provided comparator.
  */
@@ -33,14 +33,14 @@ abstract class MinHeap<V> {
   int get length;
 
   /**
-   * Add a value to the heap. For bulk-adds, please prefer [addAll].
+   * Adds a value to the heap. For bulk-adds, please prefer [addAll].
    * 
-   * This has a complexity is `O(log(n))`, where n is [length].
+   * This has a complexity of `O(log(n))`, where `n` is [length].
    */
   void add(V value);
 
   /**
-   * Add values to the heap.
+   * Adds values to the heap.
    * 
    * This is the preferred way of addind multiple values to the heap: it has
    * a complexity of `O(n)` (where n is the final length of the heap), whereas
@@ -58,23 +58,23 @@ abstract class MinHeap<V> {
   /**
    * Removes the smallest value and returns it, or returns null if [isEmpty].
    * 
-   * This has a complexity of `O(log(n))`, where n is [length].
+   * This has a complexity of `O(log(n))`, where `n` is [length].
    */
   V removeMin();
   
   /**
    * Removes all the values using [removeMin] and returns a list of sorted values.
    * 
-   * This has a complexity of `O(n * log(n))`, where n is [length].
+   * This has a complexity of `O(n * log(n))`, where `n` is [length].
    */
   List<V> removeAll();
 }
 
 /**
- * Sort items with a [MinHeap] using their natural ordering
+ * Sorts items with a [MinHeap] using their natural ordering
  * (if they extend [Comparable]) or the provided comparator.
  * 
- * This has a complexity of `O(n * log(n))` where n is the number of items.
+ * This has a complexity of `O(n * log(n))` where `n` is the number of items.
  */
 List heapSort(Iterable items, {Comparator comparator: Comparable.compare}) =>
     (new MinHeap(comparator: comparator)..addAll(items)).removeAll();

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -15,7 +15,10 @@
 part of quiver.collection;
 
 /**
- * Minimum heap.
+ * Minimum heap: data structure optimized to add comparable values in linear
+ * time and continuously removing their minimum value in logarithmic time.
+ * 
+ * Uses the elements' natural ordering or a user-provided comparator.
  */
 abstract class MinHeap<V> {
   Comparator<V> comparator;
@@ -29,7 +32,11 @@ abstract class MinHeap<V> {
   bool get isNotEmpty;
   int get length;
 
-  /// Add a value to the heap (complexity is `O(log(n))`, where n is [length]).
+  /**
+   * Add a value to the heap. For bulk-adds, please prefer [addAll].
+   * 
+   * This has a complexity is `O(log(n))`, where n is [length].
+   */
   void add(V value);
 
   /**
@@ -51,16 +58,14 @@ abstract class MinHeap<V> {
   /**
    * Removes the smallest value and returns it, or returns null if [isEmpty].
    * 
-   * This has a complexity of `O(log(n))`, where n is [length]
-   * (assuming [List.removeLast] has a constant-time complexity).
+   * This has a complexity of `O(log(n))`, where n is [length].
    */
   V removeMin();
   
   /**
    * Removes all the values using [removeMin] and returns a list of sorted values.
    * 
-   * This has a complexity of `O(n * log(n))`, where n is [length]
-   * (assuming [List.removeLast] has a constant-time complexity).
+   * This has a complexity of `O(n * log(n))`, where n is [length].
    */
   List<V> removeAll();
 }
@@ -74,6 +79,11 @@ abstract class MinHeap<V> {
 List heapSort(Iterable items, {Comparator comparator: Comparable.compare}) =>
     (new MinHeap(comparator: comparator)..addAll(items)).removeAll();
 
+/**
+ * [List]-backed [MinHeap] implementation.
+ * 
+ * Assumes [List.removeLast] has a constant-time complexity.
+ */
 class ListMinHeap<V> extends MinHeap<V> {
   final List<V> _values = [];
 

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -15,9 +15,10 @@
 part of quiver.collection;
 
 /**
- * Minimum heap: data structure optimized to add comparable values in linear
- * time and continuously remove their minimum value in logarithmic time.
- * 
+ * Minimum heap: data structure containing comparable values, optimized to do
+ * bulk insertions in linear time, single insertions in amortized logarithmic
+ * time, and continuous removals of their minimum value in logarithmic time.
+ *
  * Uses the elements' natural ordering or a user-provided comparator.
  */
 abstract class MinHeap<V> {
@@ -34,14 +35,14 @@ abstract class MinHeap<V> {
 
   /**
    * Adds a value to the heap. For bulk-adds, please prefer [addAll].
-   * 
-   * This has a complexity of `O(log(n))`, where `n` is [length].
+   *
+   * This has an amortized complexity of `O(log(n))`, where `n` is [length].
    */
   void add(V value);
 
   /**
    * Adds values to the heap.
-   * 
+   *
    * This is the preferred way of addind multiple values to the heap: it has
    * a complexity of `O(n)` (where n is the final length of the heap), whereas
    * calling [add] repeatedly has a complexity of `O(n * log(n))`.
@@ -50,21 +51,21 @@ abstract class MinHeap<V> {
 
   /**
    * Returns the smallest value, or null if [isEmpty].
-   * 
+   *
    * This has a constant-time complexity.
    */
   V min();
-  
+
   /**
    * Removes the smallest value and returns it, or returns null if [isEmpty].
-   * 
+   *
    * This has a complexity of `O(log(n))`, where `n` is [length].
    */
   V removeMin();
-  
+
   /**
    * Removes all the values using [removeMin] and returns a list of sorted values.
-   * 
+   *
    * This has a complexity of `O(n * log(n))`, where `n` is [length].
    */
   List<V> removeAll();
@@ -73,7 +74,7 @@ abstract class MinHeap<V> {
 /**
  * Sorts items with a [MinHeap] using their natural ordering
  * (if they extend [Comparable]) or the provided comparator.
- * 
+ *
  * This has a complexity of `O(n * log(n))` where `n` is the number of items.
  */
 List heapSort(Iterable items, {Comparator comparator: Comparable.compare}) =>
@@ -81,21 +82,26 @@ List heapSort(Iterable items, {Comparator comparator: Comparable.compare}) =>
 
 /**
  * [List]-backed [MinHeap] implementation.
- * 
+ *
  * Assumes [List.removeLast] has a constant-time complexity.
  */
 class ListMinHeap<V> extends MinHeap<V> {
   final List<V> _values = [];
 
   ListMinHeap({Comparator<V> comparator: Comparable.compare}) : super._(comparator);
-  
-  @override bool get isEmpty => _values.isEmpty;
-  @override bool get isNotEmpty => _values.isNotEmpty;
-  @override int get length => _values.length;
-    
-  @override V min() => _values.isEmpty ? null : _values.first;
 
-  @override V removeMin() {
+  @override
+  bool get isEmpty => _values.isEmpty;
+  @override
+  bool get isNotEmpty => _values.isNotEmpty;
+  @override
+  int get length => _values.length;
+
+  @override
+  V min() => _values.isEmpty ? null : _values.first;
+
+  @override
+  V removeMin() {
     if (_values.isEmpty) {
       return null;
     } else {
@@ -108,10 +114,10 @@ class ListMinHeap<V> extends MinHeap<V> {
       return value;
     }
   }
-  
+
   /**
    * Removes all the values using [removeMin] and returns a list of sorted values.
-   */ 
+   */
   List<V> removeAll() {
     var n = length;
     var result = new List(n); // Avoid growing the list needlessly.
@@ -122,19 +128,25 @@ class ListMinHeap<V> extends MinHeap<V> {
     return result;
   }
 
-  /// Logarithmic-time single-add.
-  @override void add(V value) {
+  /**
+   * Amortized logarithmic-time single-add.
+   *
+   * Assumes [List.add] has an amortized constant complexity.
+   */
+  @override
+  void add(V value) {
     var values = _values;
     var index = values.length;
     values.add(value);
     _bubbleUp(index);
   }
-  
+
   /// Linear-time bulk-add.
-  @override void addAll(Iterable<V> values) {
+  @override
+  void addAll(Iterable<V> values) {
     if (values.isNotEmpty) {
       _values.addAll(values);
-      for (var i = (_values.length / 2).floor(); i >= 0; i--) {
+      for (var i = _values.length ~/ 2; i >= 0; i--) {
         _bubbleDown(i);
       }
     }
@@ -156,8 +168,7 @@ class ListMinHeap<V> extends MinHeap<V> {
   _bubbleDown(int i) {
     var values = _values;
     var length = values.length;
-    var halfLength = (length / 2).floor();
-    while (i < halfLength) {
+    while (i < length ~/ 2) {
       var value = values[i];
       var offset = i * 2;
       var left = offset + 1;
@@ -196,7 +207,7 @@ class ListMinHeap<V> extends MinHeap<V> {
       i = j;
     }
   }
-  
+
   _swap(int i, int j) {
     var tmp = _values[i];
     _values[i] = _values[j];

--- a/lib/src/collection/heap.dart
+++ b/lib/src/collection/heap.dart
@@ -163,14 +163,14 @@ class ListMinHeap<V> extends MinHeap<V> {
       var left = offset + 1;
       var right = offset + 2;
       if (left >= length) {
-        // End case: child1 and child2 do not exist.
+        // End case: leftValue and rightValue do not exist.
         return;
       }
       var leftValue = values[left];
       var moreThanChild1 = comparator(value, leftValue) > 0;
       var j;
       if (right >= length) {
-        // End case: child2 does not exist.
+        // End case: rightValue does not exist.
         if (moreThanChild1) {
           j = left;
         }

--- a/test/collection/all_tests.dart
+++ b/test/collection/all_tests.dart
@@ -16,6 +16,7 @@ library quiver.collection.all_tests;
 
 import 'bimap_test.dart' as bimap;
 import 'collection_test.dart' as collection;
+import 'heap_test.dart' as heap;
 import 'multimap_test.dart' as multimap;
 import 'treeset_test.dart' as treeset;
 import 'delegates/iterable_test.dart' as iterable;
@@ -27,6 +28,7 @@ import 'delegates/set_test.dart' as set;
 main() {
   bimap.main();
   collection.main();
+  heap.main();
   multimap.main();
   iterable.main();
   list.main();

--- a/test/collection/heap_test.dart
+++ b/test/collection/heap_test.dart
@@ -1,0 +1,77 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.collection.heap_test;
+
+import 'package:quiver/collection.dart';
+import 'package:unittest/unittest.dart';
+
+void main() {
+  group('MinHeap', () {
+    test('should be a list-backed min heap', () {
+      var map = new MinHeap();
+      expect(map is ListMinHeap, true);
+    });
+  });
+
+  group('ListMinHeap', () {
+    test('should initialize empty', () {
+      var map = new ListMinHeap();
+      expect(map.isEmpty, true);
+      expect(map.isNotEmpty, false);
+    });
+
+    test('should not be empty after adding', () {
+      var map = new ListMinHeap<String>()..add('v');
+      expect(map.isEmpty, false);
+      expect(map.isNotEmpty, true);
+    });
+
+    test('should return the number of values as length', () {
+      var map = new ListMinHeap<String>();
+      expect(map.length, 0);
+      map
+        ..add('v1')
+        ..add('v2')
+        ..add('v3');
+      expect(map.length, 3);
+    });
+  });
+
+  group('heapSort', () {
+    test('should support weird inputs', () {
+      expect(heapSort([]), []);
+      expect(heapSort(["a"]), ["a"]);
+      // TODO(ochafik): Have [Comparable.compare] to support nulls?
+      // expect(heapSort([null]), [null]);
+      // expect(heapSort([null, null]), [null, null]);
+      // expect(heapSort(["a", null]), ["a", null]);
+    });
+    test('should sort different values', () {
+      expect(heapSort(["a", "b"]), ["a", "b"]);
+      expect(heapSort(["b", "a"]), ["a", "b"]);
+      expect(heapSort(["a", "b", "c"]), ["a", "b", "c"]);
+      expect(heapSort(["a", "c", "b"]), ["a", "b", "c"]);
+      expect(heapSort(["c", "b", "a"]), ["a", "b", "c"]);
+      expect(heapSort(["d", "c", "b", "a"]), ["a", "b", "c", "d"]);
+      expect(heapSort(["e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e"]);
+      expect(heapSort(["f", "e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e", "f"]);
+    });
+    test('should respect duplicates values', () {
+      expect(heapSort(["a", "a", "b"]), ["a", "a", "b"]);
+      expect(heapSort(["a", "b", "a"]), ["a", "a", "b"]);
+      expect(heapSort(["b", "b", "a"]), ["a", "b", "b"]);
+    });
+  });
+}

--- a/test/collection/heap_test.dart
+++ b/test/collection/heap_test.dart
@@ -98,7 +98,7 @@ void main() {
       }
     });
 
-    test('should respect duplicates values', () {
+    test('should respect duplicate values', () {
       expect(heapSort(["a", "a", "b"]), ["a", "a", "b"]);
       expect(heapSort(["a", "b", "a"]), ["a", "a", "b"]);
       expect(heapSort(["b", "b", "a"]), ["a", "b", "b"]);

--- a/test/collection/heap_test.dart
+++ b/test/collection/heap_test.dart
@@ -74,6 +74,7 @@ void main() {
       expect(heapSort([]), []);
       expect(heapSort(["a"]), ["a"]);
     });
+
     test('should sort different values', () {
       expect(heapSort(["a", "b"]), ["a", "b"]);
       expect(heapSort(["b", "a"]), ["a", "b"]);
@@ -84,6 +85,7 @@ void main() {
       expect(heapSort(["e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e"]);
       expect(heapSort(["f", "e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e", "f"]);
     });
+
     test('should handle sequences of arbitrary sizes', () {
       for (int i = 1; i < 100; i++) {
         // Sorted seq should be unchanged.
@@ -95,10 +97,20 @@ void main() {
         expect(heapSort(rseq), seq);
       }
     });
+
     test('should respect duplicates values', () {
       expect(heapSort(["a", "a", "b"]), ["a", "a", "b"]);
       expect(heapSort(["a", "b", "a"]), ["a", "a", "b"]);
       expect(heapSort(["b", "b", "a"]), ["a", "b", "b"]);
+    });
+
+    test('should use custom comparator', () {
+      Comparator<String> comp = (String a, String b) {
+        var d = a.length - b.length;
+        return (d == 0) ? a.compareTo(b) : d;
+      };
+      expect(heapSort(["b", "aa", "a", "aaa", "c", "aaaa"], comparator: comp),
+          ["a", "b", "c", "aa", "aaa", "aaaa"]);
     });
   });
 }

--- a/test/collection/heap_test.dart
+++ b/test/collection/heap_test.dart
@@ -16,6 +16,7 @@ library quiver.collection.heap_test;
 
 import 'package:quiver/collection.dart';
 import 'package:unittest/unittest.dart';
+import 'package:quiver/iterables.dart';
 
 void main() {
   group('MinHeap', () {
@@ -41,22 +42,37 @@ void main() {
     test('should return the number of values as length', () {
       var map = new ListMinHeap<String>();
       expect(map.length, 0);
-      map
-        ..add('v1')
-        ..add('v2')
-        ..add('v3');
+      map..add('v1')..add('v2')..add('v3');
       expect(map.length, 3);
+      map..addAll(['v0']);
+      expect(map.length, 4);
+      
+      map = new ListMinHeap<String>();
+      map..addAll(['v1', 'v2', 'v3']);
+      expect(map.length, 3);
+    });
+
+    test('should remove its min value', () {
+      var map = new ListMinHeap<int>()..add(3)..add(1)..add(2);
+      expect(map.removeMin(), 1);
+      expect(map.removeMin(), 2);
+      expect(map.removeMin(), 3);
+      
+      map = new ListMinHeap<int>()..addAll([3, 1, 2]);
+      expect(map.removeAll(), [1, 2, 3]);
+    });
+
+    test('should return null / empty when removing from empty heap', () {
+      var map = new ListMinHeap<int>();
+      expect(map.removeMin(), null);
+      expect(map.removeAll(), []);
     });
   });
 
   group('heapSort', () {
-    test('should support weird inputs', () {
+    test('should support empty or singleton inputs', () {
       expect(heapSort([]), []);
       expect(heapSort(["a"]), ["a"]);
-      // TODO(ochafik): Have [Comparable.compare] to support nulls?
-      // expect(heapSort([null]), [null]);
-      // expect(heapSort([null, null]), [null, null]);
-      // expect(heapSort(["a", null]), ["a", null]);
     });
     test('should sort different values', () {
       expect(heapSort(["a", "b"]), ["a", "b"]);
@@ -67,6 +83,17 @@ void main() {
       expect(heapSort(["d", "c", "b", "a"]), ["a", "b", "c", "d"]);
       expect(heapSort(["e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e"]);
       expect(heapSort(["f", "e", "d", "c", "b", "a"]), ["a", "b", "c", "d", "e", "f"]);
+    });
+    test('should handle sequences of arbitrary sizes', () {
+      for (int i = 1; i < 100; i++) {
+        // Sorted seq should be unchanged.
+        var seq = range(0, i);
+        expect(heapSort(seq), seq);
+
+        // Reverse seq should be sorted.
+        var rseq = range(i - 1, -1, -1);
+        expect(heapSort(rseq), seq);
+      }
     });
     test('should respect duplicates values', () {
       expect(heapSort(["a", "a", "b"]), ["a", "a", "b"]);


### PR DESCRIPTION
This prepares the ground for a better merge algorithm (I'll submit [another pull-request](https://github.com/ochafik/quiver-dart/compare/ochafik:heap...merge-heap?expand=1)) in `O(n * log(m))` instead of `O(n * m)`.

(where m is the number of iterables and n is the total number of items)
