### PR TITLE
Change signature of classImplements()

### DIFF
--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -26,18 +26,19 @@ Symbol getTypeName(Type t) => reflectClass(t).qualifiedName;
  * Returns true if [o] implements [type].
  */
 bool implements(Object o, Type type) =>
-    classImplements(reflect(o).type, getTypeName(type));
+    classImplements(reflect(o).type, reflectClass(type));
 
 /**
- * Returns true if [m], its superclasses or interfaces have the qualified name
- * [name].
+ * Returns true if the class represented by [classMirror] implements the class
+ * represented by [interfaceMirror].
  */
-bool classImplements(ClassMirror m, Symbol name) {
-  if (m == null) return false;
-  if (m.qualifiedName == name) return true;
-  if (m.qualifiedName == const Symbol('dart.core.Object')) return false;
-  if (classImplements(m.superclass, name)) return true;
-  if (m.superinterfaces.any((i) => classImplements(i, name))) return true;
+bool classImplements(ClassMirror classMirror, ClassMirror interfaceMirror) {
+  if (classMirror == null) return false;
+  // TODO: change to comparing mirrors when dartbug.com/19781 is fixed
+  if (classMirror.qualifiedName == interfaceMirror.qualifiedName) return true;
+  if (classImplements(classMirror.superclass, interfaceMirror)) return true;
+  if (classMirror.superinterfaces.any(
+      (i) => classImplements(i, interfaceMirror))) return true;
   return false;
 }
 

--- a/test/mirrors_test.dart
+++ b/test/mirrors_test.dart
@@ -49,17 +49,17 @@ main() {
     test('should return true if an class implements an interface', () {
       var foo = new Foo();
       var mirror = reflect(foo).type;
-      expect(classImplements(mirror, getTypeName(Object)), true);
-      expect(classImplements(mirror, getTypeName(Foo)), true);
-      expect(classImplements(mirror, getTypeName(Comparable)), true);
-      expect(classImplements(mirror, getTypeName(Iterable)), true);
+      expect(classImplements(mirror, reflectClass(Object)), true);
+      expect(classImplements(mirror, reflectClass(Foo)), true);
+      expect(classImplements(mirror, reflectClass(Comparable)), true);
+      expect(classImplements(mirror, reflectClass(Iterable)), true);
     });
 
     test("should return false if an object doesn't implement an interface", () {
       var foo = new Foo();
       var mirror = reflect(foo).type;
-      expect(classImplements(mirror, getTypeName(String)), false);
-      expect(classImplements(mirror, getTypeName(num)), false);
+      expect(classImplements(mirror, reflectClass(String)), false);
+      expect(classImplements(mirror, reflectClass(num)), false);
     });
 
   });


### PR DESCRIPTION
I think this is a better API. We didn't have reflectClass() when I wrote the originals.
