### PR TITLE
Add retry.dart and retry_test.dart to quiver.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,42 @@ events with optional anchor time. For example:
   });
 ```
 
+`retry` provides a mechanism for retrying a `Future` until it succeeds
+(or some terminal failure condition occurs, as decided by the caller-supplied
+`OnErrorFunc`), with additional features such as random back-off (via a
+caller-supplied `RetryDelayFunc`). `retry` also contains a number of
+pre-defined helper functions such as `makeDelayBackOffRandom` that simplify
+common usage. For example:
+```dart
+  import 'package:quiver/async.dart' as retry;
+  // Create a RetryDelayFunc that starts with a 500 microsecond delay and
+  // then backs off exponentially plus a random factor, up to a maximum
+  // retry delay of 5 milliseconds.
+  retry.RetryDelayFunc someDelay = retry.makeDelayBackOffRandom(
+      new Duration(microseconds: 500), cap: new Duration(milliseconds: 5));
+
+  // Trivial example Function that increments a counter and "fails" by
+  // throwing the value as an exception, until a maximum (arbitrarily 25 in
+  // this example) is reached, at which point the Function "succeeds" by
+  // *not* throwing an exception, but instead returning the value.
+  int val = 0;
+  someFunc() {
+    if (val < 25) { val += 1; throw val; }
+    return val;
+  };
+
+  // A NewFuture Function that returns a Future which invokes someFunc.
+  futureSomeFunc() => new Future(someFunc);
+
+  // Start retrying someFunc as a Future, with a retryDelay between attempts
+  // defined by someDelay (and with the default retriesInfinite as the
+  // OnErrorFunc).
+  retry.start(futureSomeFunc, retryDelay: someDelay).then(
+      (v) { ...on success, do something with final value... })
+    .catchError(
+      (e) { ...failed to succeed (will not happen in this example)... });
+```
+
 [quiver.async]: http://google.github.io/quiver-dart/#quiver/quiver-async
 
 ## [quiver.cache][]

--- a/lib/async.dart
+++ b/lib/async.dart
@@ -15,6 +15,7 @@
 library quiver.async;
 
 import 'dart:async';
+import 'dart:math' as math;
 
 import 'package:quiver/time.dart';
 
@@ -23,6 +24,7 @@ part 'src/async/future_group.dart';
 part 'src/async/future_stream.dart';
 part 'src/async/iteration.dart';
 part 'src/async/metronome.dart';
+part 'src/async/retry.dart';
 part 'src/async/stream_router.dart';
 
 /**

--- a/lib/src/async/retry.dart
+++ b/lib/src/async/retry.dart
@@ -1,0 +1,330 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.async;
+
+/**
+ * Defines the type of [Function] that is called by [start] on each
+ * catchError. Functions of this type are supplied the caught [err], the
+ * failed [retry] count, and the [elapsed] Duration of all attempts so far.
+ *
+ * An OnErrorFunc returns null if the next attempt (the '[retry] + 1' retry,
+ * AKA the '[retry] + 2' attempt) should be made, or an error Object if
+ * retrying should cease.
+ *
+ * [retry] has a value of [INITIAL_TRY] (zero) the first time the
+ * OnErrorFunc is invoked, just after the failure of the first attempt
+ * (which is not, techically, a "retry", but *the* "try") of the
+ * newFuture() call. This zero value is provided so a custom OnErrorFunc
+ * can implement different behavior between the failure of the initial
+ * attempt (e.g. switch the UI to displaying an error message) and failures
+ * of subsequent retries (e.g. update the displayed error message). [retry]
+ * will be [FIRST_RETRY] (one) when the OnErrorFunc is next called if the
+ * first "re"-try failed, and increment from there for subsequent calls.
+ *
+ * [elapsed] is the total elapsed time so far, including any time used by
+ * the initial failed attempt. [elapsed] is a snapshot captured each
+ * time the newFuture() call fails. For consistency, the same "snapshot"
+ * value of [elapsed] is passed to both the OnErrorFunc and the
+ * [RetryDelayFunc] for a given failed newFuture() call.
+ */
+typedef Object OnErrorFunc(Object err, int retry, Duration elapsed);
+
+const int INITIAL_TRY = 0;
+const int NO_TRIES = INITIAL_TRY - 1;
+const int FIRST_RETRY = INITIAL_TRY + 1;
+
+/**
+ * Defines the type of [Function] that is called by [start] prior to
+ * scheduling a newFuture retry to determine the delay before the retry is
+ * attempted. Functions of this type are supplied the upcoming [retry] and
+ * the [elapsed] Duration of all attempts so far.
+ *
+ * A RetryDelayFunc returns a Duration containing the delay to be used for
+ * scheduling the upcoming newFuture() retry (the one that is indicated by
+ * the [retry] value).
+ *
+ * The first time the RetryDelayFunc is called, [retry] has a value of
+ * [FIRST_RETRY] (one), corresponding to the first upcoming newFuture()
+ * retry. "Upcoming" because this is a request for the delay to
+ * be used when scheduling that future retry, not the retry (or initial
+ * attempt) that just failed.  This first time request is just after the
+ * failure of the first newFuture() call that was attempted, and just before
+ * the first newFuture() retry will be scheduled. [retry] increments from
+ * there for subsequent calls.
+ *
+ * [elapsed] is the total elapsed time so far, including any time used by
+ * the initial failed attempt. [elapsed] is a snapshot captured each
+ * time the newFuture() call fails. For consistency, the same "snapshot"
+ * value of [elapsed] is passed to both the RetryDelayFunc and the
+ * [OnErrorFunc] for a given failed newFuture() call.
+ */
+typedef Duration RetryDelayFunc(int retry, Duration elapsed);
+
+/**
+ * NewFuture is a [Function] type that accepts no arguments and returns
+ * a Future. It is the Function type of the newFuture argument supplied
+ * when [start] is called.
+ */
+typedef Future NewFuture();
+
+/**
+ * A default [OnErrorFunc] that always returns null. This results in
+ * never-ending retries if some newFuture() call does not eventually
+ * succeed.
+ */
+Object retriesInfinite(Object err, int retry, Duration elapsed) => null;
+
+/**
+ * A simple [OnErrorFunc] that always returns the supplied error, thus
+ * resulting in no retries after the failure of the initial newFuture()
+ * call attempt.
+ */
+Object retriesNone(Object err, int retry, Duration elapsed) => err;
+
+/**
+ * Returns an [OnErrorFunc] that returns the supplied error once the
+ * count of failed retries equals [max]. When [retry] equals [max], this
+ * means that:
+ * 1) the initial attempt (the "try" before any retries) has failed
+ * 2) [max] retries were executed and all failed, since an OnErrorFunc
+ *    is called just after the failure of the [retry] Otherwise, the returned
+ * [OnErrorFunc] returns null.
+ */
+OnErrorFunc makeRetriesMax(int max) {
+  return ((Object err, int retry, Duration elapsed) {
+    return (retry >= max) ? err : null;
+  });
+}
+
+/**
+ * Returns an [OnErrorFunc] that returns the supplied error once the total
+ * [Duration] of all attempts is equal to or exceeds [max]. Otherwise, the
+ * returned [OnErrorFunc] returns null.
+ */
+OnErrorFunc makeRetriesElapsed(Duration max) {
+  return ((Object err, int retry, Duration elapsed) {
+    return (elapsed >= max) ? err : null;
+  });
+}
+
+/**
+ * Simply combines [makeRetriesMax] and [makeRetriesElapsed], returning
+ * an [OnErrorFunc] that itself returns the supplied error if either the
+ * [maxRetries] or [maxElapsed] limits are reached. Otherwise, the
+ * returned [OnErrorFunc] returns null.
+ */
+OnErrorFunc makeRetriesLimited(int maxRetries, Duration maxElapsed) {
+  OnErrorFunc retriesMax = makeRetriesMax(maxRetries);
+  OnErrorFunc retriesElapsed = makeRetriesElapsed(maxElapsed);
+
+  return ((Object err, int retry, Duration elapsed) {
+    Object error = retriesMax(err, retry, elapsed);
+    if (error != null) { return error; }
+    return retriesElapsed(err, retry, elapsed);
+  });
+}
+
+const Duration NO_DELAY = Duration.ZERO;
+
+/**
+ * A trivial [RetryDelayFunc] that indicates there should be no delay
+ * before attempting the next newFuture retry. [NO_DELAY] (Duration.ZERO)
+ * is always returned.
+ */
+Duration delayNone(int retry, Duration elapsed) => NO_DELAY;
+
+/**
+ * Returns a somewhat trivial [RetryDelayFunc] that simply always returns
+ * the supplied [delay].
+ */
+RetryDelayFunc makeDelayFixed(Duration delay) {
+  return ((int retry, Duration elapsed) {
+    return delay;
+  });
+}
+
+math.Random _rnd = new math.Random();
+
+/**
+ * A helper function (exposed for writing custom [RetryDelayFunc]) that
+ * returns the supplied [delay], adjusted by a random offset in the range
+ * of +/- [delay] * [scale], intended for use with the Future.delayed
+ * constructor.
+ *
+ * Negative [delay] Durations and [scale] factors outside of the range
+ * (0.0, 1.0) exclusive can return negative Durations, which are basically
+ * meaninglesss, but are accepted anyway, since they just result in
+ * "no delay" for the Future.delayed constructor.
+ */
+Duration randomDelay(Duration delay, double scale) {
+  Duration offset = delay * scale;
+  return delay + ((offset * 2.0 * _rnd.nextDouble()) - offset);
+}
+
+const double DEFAULT_SCALE = 0.5;
+
+/**
+ * Returns a [RetryDelayFunc] that returns the supplied [delay] adjusted,
+ * each time called, by a [randomDelay] using [scale]. If delay is a zero or
+ * negative duration, the [delayNone] [RetryDelayFunc] is returned instead.
+ *
+ * [scale] is truncated to the range (0.0, 1.0) exclusive, to avoid
+ * producing negative delays.
+ *
+ * The principal use of this delay strategy is to avoid surges of
+ * simultaneously-retrying clients in the event of a server-side failure.
+ */
+RetryDelayFunc makeDelayRandom(Duration delay, {double scale: DEFAULT_SCALE}) {
+  if (delay <= NO_DELAY) { return delayNone; }
+  scale = scale.clamp(double.MIN_POSITIVE, 1.0 - double.MIN_POSITIVE);
+  return ((int retry, Duration elapsed) => randomDelay(delay, scale));
+}
+
+const Duration NO_CAP = Duration.ZERO;
+
+/**
+ * A helper function (exposed for writing custom [RetryDelayFunc]) that
+ * returns [delay] capped at an optional [cap], which if null or less than
+ * or equal to [NO_CAP] (Duration.ZERO) indicates "no cap" and delay is
+ * returned unchanged.
+ */
+Duration capDelay(Duration delay, Duration cap) {
+  if ((cap == null) || (cap <= NO_CAP)) {
+    return delay;  // No cap or explicitly NO_CAP specified.
+  } else {
+    return (delay > cap) ? cap : delay;
+  }
+}
+
+/**
+ * A helper function (exposed for writing custom [RetryDelayFunc]) that
+ * returns a doubled [delay], optionally capped via capDelay. Called
+ * repeatedly with the previous result, this results in an exponentially
+ * increasing delay (up to [cap], which defaults to [NO_CAP]).
+ */
+Duration backOffDelay(Duration delay, {Duration cap: NO_CAP}) {
+  return capDelay(delay * 2.0, cap);
+}
+
+/**
+ * Returns a [RetryDelayFunc] that returns a [delay] that is exponentially
+ * increasing with each subsequent call to that returned [RetryDelayFunc],
+ * optionally capped at a [cap] (defaults to [NO_CAP]).
+ */
+RetryDelayFunc makeDelayBackOff(Duration delay, {Duration cap: NO_CAP}) {
+  return ((int retry, Duration elapsed) {
+    // Return the existing delay value, possibly capped.
+    Duration capped = capDelay(delay, cap);
+    // Compute the value to be used on the next iteration, and replace the
+    // existing delay with that inside the closure.
+    delay = backOffDelay(capped);
+    return capped;
+  });
+}
+
+/**
+ * Returns a [RetryDelayFunc] that returns a [delay] that is both
+ * exponentially increasing and includes a random adjustment with the
+ * specified [scale] (default is +/- 1/2 each subsequent delay) that is
+ * also optionally capped at a [cap] (which defaults to [NO_CAP]).
+ */
+RetryDelayFunc makeDelayBackOffRandom(Duration delay,
+    {double scale: DEFAULT_SCALE, Duration cap: NO_CAP}) {
+  return ((int retry, Duration elapsed) {
+    // Adjust the current delay a random offset.
+    Duration random = randomDelay(delay, scale);
+    // Insure randomly-adjusted delay does not exceed the specified cap.
+    Duration capped = capDelay(random, cap);
+    // Compute the value to be used on the next iteration, and replace the
+    // existing delay with that inside the closure.
+    delay = backOffDelay(capped);
+    return capped;
+  });
+}
+
+/**
+ * Accepts a [newFuture] [Function] which returns a [Future], an optional
+ * [onError] [OnErrorFunc], an optional [retryDelay] [RetryDelayFunc], and
+ * an optional [runTime] [Stopwatch].
+ *
+ * If supplied, onError is called just after each error that is caught by
+ * the .catchError of the Future returned by newFuture (after the initial
+ * failed attempt and any subsequent failed retries). Otherwise,
+ * [retriesInfinite] is the default.
+ *
+ * If supplied, retryDelay is called just before each upcoming retry (but
+ * not before the initial attempt, which is the "try", not a "retry") to
+ * determine the delay that should elapse before that next retry is
+ * executed. Otherwise, [delayNone] is the default.
+ *
+ * The caller can optionally supply a Stopwatch if examining or monitoring
+ * the elapsed time of the Future retries outside of onError and retryDelay
+ * is desired. If supplied, [stop] and [reset] will be called on it before
+ * [start] is called to begin counting the elapsed time.  A Stopwatch
+ * supplied by the caller in this way can be observed via its [elapsed]
+ * property, but must not otherwise be manipulated or altered (that is, do
+ * not call stop, reset, or start on it). If not supplied by the caller, a
+ * new Stopwatch is created internally and used.
+ *
+ * This method returns a Future that can be used to determine if a Future
+ * produced by newFuture did (eventually) succeed before the [onError]
+ * function prematurely terminated any additional newFuture attempts.
+ */
+Future start(NewFuture newFuture, {
+    OnErrorFunc onError: retriesInfinite,
+    RetryDelayFunc retryDelay: delayNone,
+    Stopwatch runTime}) {
+  // Closures will "capture" these local variables.
+  int retries = INITIAL_TRY;
+  if (runTime != null) {
+    runTime.stop();
+    runTime.reset();
+  } else {
+    runTime = new Stopwatch();
+  }
+  runTime.start();
+
+  // Wrap the Future result to return the result passed to .then after
+  // stopping the runTime Stopwatch.
+  thenCompleted(futureResult) {
+    runTime.stop();
+    return futureResult;
+  };
+
+  computation() {
+    return newFuture()
+      .then(thenCompleted)
+      .catchError((e) {
+        // Snapshot values so far, for onError and retryDelay consistency.
+        int onErrorRetry = retries;
+        Duration atOnError = runTime.elapsed;
+        Object err = onError(e, onErrorRetry, atOnError);
+
+        if (err != null) {
+          runTime.stop();
+          return new Future.error(err);
+        } else {
+          // onError returned null, thus indicating that (at least) one
+          // more retry of newFuture() should be scheduled.
+          int nextRetry = onErrorRetry + 1;
+          retries = nextRetry;
+          Duration delay = retryDelay(nextRetry, atOnError);
+          return new Future.delayed(delay, computation);
+        }
+      });
+  };
+
+  return computation();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,6 +7,7 @@ authors:
 - Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
 - David Morgan <davidmorgan@google.com>
 - John McDole <codefu@google.com>
+- Todd Larsen <tlarsen@google.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 documentation: http://google.github.io/quiver-dart/

--- a/test/async/all_tests.dart
+++ b/test/async/all_tests.dart
@@ -20,6 +20,7 @@ import 'future_group_test.dart' as future_group;
 import 'future_stream_test.dart' as future_stream;
 import 'iteration_test.dart' as iteration;
 import 'metronome_test.dart' as metronome;
+import 'retry_test.dart' as retry;
 import 'stream_router_test.dart' as stream_router;
 
 main() {
@@ -29,5 +30,6 @@ main() {
   future_stream.main();
   metronome.main();
   iteration.main();
+  retry.main();
   stream_router.main();
 }

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -1,0 +1,445 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the 'License');
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.async.retry_test;
+
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:quiver/async.dart' as retry;
+import 'package:unittest/unittest.dart';
+
+main() {
+  const int maxI = 25;  // This value is arbitrary.
+
+  group('start() retries', () {
+    const int rMax = maxI ~/ 2;  // Anything in (1, maxI) exclusive.
+    Duration zEl = new Duration();  // Zero elapsed time.
+
+    test('none', () {
+      int nI = 0;
+      nFuture() {
+        if (nI < maxI) { nI += 1; throw nI; }
+        return nI;
+      };
+      nNewFuture() => new Future(nFuture);
+
+      // With retriesNone, do not retry at all.
+      return retry.start(nNewFuture, onError: retry.retriesNone)
+        .then((v) {
+          fail(".then() should not be executed for this test: $v");
+        })
+        .catchError((e) {
+          // No retries if retriesNone.
+          expect(nI, 1);  // Only the initial, failed attempt.
+          expect(e, 1);  // nFuture threw the value of nI after one attempt.
+        });
+    });
+
+    test('infinite', () {
+      int iI = 0;
+      iFuture() {
+        if (iI < maxI) { iI += 1; throw iI; }
+        return iI;
+      };
+      iNewFuture() => new Future(iFuture);
+
+      // With default retriesInfinite, retry until no error thrown.
+      return retry.start(iNewFuture)
+        .then((v) {
+          // iFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(iI, maxI);
+        });
+    });
+
+    test('max count', () {
+      int mI = 0;
+      mFuture() {
+        if (mI < maxI) { mI += 1; throw mI; }
+        return mI;
+      };
+      mNewFuture() => new Future(mFuture);
+
+      // With some RetriesMax, retry a limited number of multiple times.
+      return retry.start(mNewFuture, onError: retry.makeRetriesMax(rMax))
+        .then((v) {
+          fail(".then() should not be executed for this test: $v");
+        })
+        .catchError((e) {
+          expect(mI, rMax + 1);
+          expect(e, rMax + 1);  // mFuture threw last attempted value of mI.
+        });
+    });
+
+    test('max elapsed', () {
+      int eI = 0;
+      eFuture() {
+        if (eI < maxI) { eI += 1; throw eI; }
+        return eI;
+      };
+      eNewFuture() => new Future(eFuture);
+
+      // With a zero-time RetriesElapsed, no retries after the first attempt.
+      Stopwatch eRT = new Stopwatch();
+      return retry.start(eNewFuture,
+          onError: retry.makeRetriesElapsed(zEl), runTime: eRT)
+        .then((v) {
+          fail(".then() should not be executed for this test: $v");
+        })
+        .catchError((e) {
+          // No retries zero RetriesElapsed.
+          expect(eI, 1);  // Only the initial, failed attempt.
+          expect(e, 1);  // eFuture threw the value of eI after one attempt.
+          // Some non-zero time will still have elapsed, even with zero limit.
+          expect(eRT.elapsed, greaterThan(zEl));
+        });
+    });
+
+    test('limited zero elapsed', () {
+      int lzI = 0;
+      lzFuture() {
+        if (lzI < maxI) { lzI += 1; throw lzI; }
+        return lzI;
+      };
+      lzNewFuture() => new Future(lzFuture);
+
+      // Zero-time limit ends before rMax retries.
+      Stopwatch lzRT = new Stopwatch();
+      return retry.start(lzNewFuture, onError: retry.makeRetriesLimited(
+          rMax, zEl), runTime: lzRT)
+        .then((v) {
+          fail(".then() should not be executed for this test: $v");
+        })
+        .catchError((e) {
+          // No retries zero RetriesElapsed.
+          expect(lzI, 1);  // Only the initial, failed attempt.
+          expect(e, 1);  // lzFuture threw the value of lzI after one attempt.
+          // Some non-zero time will still have elapsed, even with zero limit.
+          expect(lzRT.elapsed, greaterThan(zEl));
+        });
+    });
+
+    test('limited long elapsed', () {
+      int lrI = 0;
+      lrFuture() {
+        if (lrI < maxI) { lrI += 1; throw lrI; }
+        return lrI;
+      };
+      lrNewFuture() => new Future(lrFuture);
+
+      // rMax retries complete rather quickly.
+      Duration min5 = new Duration(minutes: 5);
+      Stopwatch lrRT = new Stopwatch();
+      return retry.start(lrNewFuture,
+          onError: retry.makeRetriesLimited(rMax, min5), runTime: lrRT)
+        .then((v) {
+          fail(".then() should not be executed for this test: $v");
+        })
+        .catchError((e) {
+          expect(lrI, rMax + 1);
+          expect(e, rMax + 1);  // mFuture threw last attempted value of mI.
+          // Some non-zero time will still have elapsed, even with zero limit.
+          expect(lrRT.elapsed, greaterThan(zEl));
+        });
+    });
+
+    test('custom onError', () {
+      int oeI = 0;
+      const oeErrors = const ["fee", "phi", "faux", "fum"];
+      String oeLast = oeErrors[oeErrors.length - 1];
+      Duration oeElMax = new Duration(milliseconds: 50);
+
+      // Simple newFuture Function that always throws a String error.
+      oeFuture() {
+        int oeIdx = oeI % oeErrors.length;
+        oeI += 1;
+        throw oeErrors[oeIdx];  // Throw a String rather than int.
+      };
+
+      oeNewFuture() => new Future(oeFuture);
+
+      // Completely made-up OnErrorFunc used to illustrate that a user-supplied
+      // OnErrorFunc can consume the error, retry count, and elapsed time
+      // any way it likes.
+      Object oeOnError(Object e, int rt, Duration el) {
+        if (e is! String)  return e;  // String is always expected, so fail.
+
+        String state = e as String;
+
+        if (state != oeLast) {
+          return null;  // Keep retrying.
+        } else {
+          if (el >= oeElMax) {
+            return e;  // Waited long enough, so exit with the "fum" error.
+          } else {
+            return null;  // Keep retrying.
+          }
+        }
+      };
+
+      Stopwatch oeRT = new Stopwatch();
+      return retry.start(oeNewFuture, onError: oeOnError, runTime: oeRT)
+        .then((state) {
+          fail(".then() should not be executed for this test: $state");
+        })
+        .catchError((e) {
+          expect((e as String), oeLast);
+          expect((e is String), true);
+          expect(oeI, greaterThanOrEqualTo(oeErrors.length));
+          expect(oeRT.elapsed, greaterThan(oeElMax));
+        });
+    });
+  });
+
+  group('start() delays', () {
+    Duration us1 = new Duration(microseconds: 1);
+    Duration us500 = new Duration(microseconds: 500);
+    Duration ms1 = new Duration(milliseconds: 1);
+    Duration ms1p5 = new Duration(microseconds: 1500);
+    Duration ms2p5 = ms1 * 2.5;
+
+    test('fixed', () {
+      int fdI = 0;
+      fdFuture() {
+        if (fdI < maxI) { fdI += 1; throw fdI; }
+        return fdI;
+      };
+      fdNewFuture() => new Future(fdFuture);
+
+      Stopwatch fdRT = new Stopwatch();
+      return retry.start(fdNewFuture, retryDelay: retry.makeDelayFixed(ms1),
+                  runTime: fdRT)
+        .then((v) {
+          // fdFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(fdI, maxI);
+          // Multiple attempts should at least exceed the fixed retry delay
+          // times the expected number of retries.
+          expect(fdRT.elapsed, greaterThan(ms1 * maxI));
+        });
+    });
+
+    test('random', () {
+      int rdI = 0;
+      rdFuture() {
+        if (rdI < maxI) { rdI += 1; throw rdI; }
+        return rdI;
+      };
+      rdNewFuture() => new Future(rdFuture);
+
+      Duration totalDelay = new Duration();
+      retry.RetryDelayFunc p5to1p5ms = retry.makeDelayRandom(ms1, scale: 0.5);
+
+      // Wrap the stock RetryDelayFunc returned by makeDelayRandom in order
+      // to test values produced by the generated function.
+      Duration rdDelay(int retry, Duration elapsed) {
+        Duration delay = p5to1p5ms(retry, elapsed);
+        expect(delay, greaterThanOrEqualTo(us500));
+        expect(delay, lessThanOrEqualTo(ms1p5));
+        if (elapsed < totalDelay) {
+          // Test environment is *not* delaying for the full requested
+          // Future.delayed value for some reason. Current elapsed time
+          // should *always* exceed the total of the delays requested so far.
+          totalDelay = elapsed;
+        }
+        totalDelay = totalDelay + delay;
+        return delay;
+      };
+
+      Stopwatch rdRT = new Stopwatch();
+      return retry.start(rdNewFuture, retryDelay: rdDelay, runTime: rdRT)
+        .then((v) {
+          // rdFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(rdI, maxI);
+          // Multiple attempts should at least exceed the total random delay
+          // for all retries.
+          expect(rdRT.elapsed, greaterThan(totalDelay));
+        });
+    });
+
+    test('backoff with cap', () {
+      int bkI = 0;
+      bkFuture() {
+        if (bkI < maxI) { bkI += 1; throw bkI; }
+        return bkI;
+      };
+      bkNewFuture() => new Future(bkFuture);
+
+      retry.RetryDelayFunc backOffMax5ms = retry.makeDelayBackOff(
+          us500, cap: ms2p5);
+      Duration bkLast = us500;
+
+      // Wrap the stock RetryDelayFunc returned by makeDelayBackOff in order
+      // to test values produced by the generated function.
+      Duration bkDelay(int retry, Duration elapsed) {
+        Duration delay = backOffMax5ms(retry, elapsed);
+        expect(delay, lessThanOrEqualTo(ms2p5));
+        expect(delay, bkLast);
+        bkLast = delay * 2.0;
+        bkLast = (bkLast > ms2p5) ? ms2p5 : bkLast;
+        return delay;
+      };
+
+      Stopwatch bkRT = new Stopwatch();
+      return retry.start(bkNewFuture, retryDelay: bkDelay, runTime: bkRT)
+        .then((v) {
+          // bkFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(bkI, maxI);
+          // Multiple attempts should at least exceed the initial retry delay
+          // times the expected number of retries.
+          expect(bkRT.elapsed, greaterThan(us500 * maxI));
+          // At least one delay should have exceeded the cap, so total
+          // elapsed time should definitely exceed that value (and then some).
+          expect(bkRT.elapsed, greaterThan(ms2p5));
+        });
+    });
+
+    test('backoff no cap', () {
+      // Smaller number of failures before success, since backoff is uncapped
+      // and growing exponentially. Otherwise, test duration is too long.
+      const int bnMaxI = 10;
+      int bnI = 0;
+      bnFuture() {
+        if (bnI < bnMaxI) { bnI += 1; throw bnI; }
+        return bnI;
+      };
+      bnNewFuture() => new Future(bnFuture);
+
+      Duration bnFirst = us1;
+      Duration bnLast = bnFirst;
+      Duration bnTotal = Duration.ZERO;
+      retry.RetryDelayFunc backOffMax5ms = retry.makeDelayBackOff(bnFirst);
+
+      // Wrap the stock RetryDelayFunc returned by makeDelayBackOff in order
+      // to test values produced by the generated function.
+      Duration bnDelay(int retry, Duration elapsed) {
+        Duration delay = backOffMax5ms(retry, elapsed);
+        expect(delay, bnLast);
+        bnTotal = bnTotal + delay;
+        bnLast = delay * 2.0;
+        return delay;
+      };
+
+      Stopwatch bnRT = new Stopwatch();
+      return retry.start(bnNewFuture, retryDelay: bnDelay, runTime: bnRT)
+        .then((v) {
+          // bnFuture is coded to eventually succeed after bnMaxI attempts,
+          // when the default retriesInfinite is the onError function.
+          expect(v, bnMaxI);
+          expect(bnI, bnMaxI);
+          // The final delay, not capped, should be the first delay times
+          // 2 to the number of interations power.
+          double lastScale = math.pow(2.0, bnMaxI);
+          expect(bnLast, bnFirst * lastScale);
+          // Expect total elapsed time to exceed (due to overhead) the sum of
+          // all (exponentially-increasing) delays.
+          expect(bnRT.elapsed, greaterThan(bnTotal));
+        });
+    });
+
+    test('backoff random', () {
+      int brI = 0;
+      brFuture() {
+        if (brI < maxI) { brI += 1; throw brI; }
+        return brI;
+      };
+      brNewFuture() => new Future(brFuture);
+
+      retry.RetryDelayFunc backOffMax5ms = retry.makeDelayBackOffRandom(
+          us500, cap: ms2p5);
+      Duration brLast = us500;
+
+      // Wrap the stock RetryDelayFunc returned by makeDelayBackOffRandom in
+      // order to test values produced by the generated function.
+      Duration brDelay(int retry, Duration elapsed) {
+        Duration delay = backOffMax5ms(retry, elapsed);
+        expect(delay, lessThanOrEqualTo(ms2p5));
+        expect(delay.inMicroseconds,
+               inInclusiveRange(brLast.inMicroseconds * 0.5,
+                                brLast.inMicroseconds * 1.5));
+        brLast = delay * 2.0;
+        brLast = (brLast > ms2p5) ? ms2p5 : brLast;
+        return delay;
+      };
+
+      Stopwatch brRT = new Stopwatch();
+      return retry.start(brNewFuture, retryDelay: brDelay, runTime: brRT)
+        .then((v) {
+          // brFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(brI, maxI);
+          // Multiple attempts should at least exceed the initial retry delay
+          // times the expected number of retries.
+          expect(brRT.elapsed, greaterThan(us500 * maxI));
+          // At least one delay should have exceeded the cap, so total
+          // elapsed time should definitely exceed that value (and then some).
+          expect(brRT.elapsed, greaterThan(ms2p5));
+        });
+    });
+
+    test('custom', () {
+      int dcI = 0;
+      dcFuture() {
+        if (dcI < maxI) { dcI += 1; throw dcI; }
+        return dcI;
+      };
+      dcNewFuture() => new Future(dcFuture);
+
+      int cappedRetry = 0;
+      const int msCapped = 100;
+      Duration capAfter = const Duration(milliseconds: msCapped);
+
+      // Custom RetryDelayFunc that returns a delay that is a multiple of
+      // the [retry] parameter, but stops increasing after a certain
+      // [elapsed] time.
+      Duration dcDelay(int retry, Duration elapsed) {
+        // Keep increasing retry multiple so long as maximum elapsed time
+        // has not been reached.
+        if (elapsed < capAfter) {
+          cappedRetry = retry;
+        }
+
+        int next = retry + 1;
+        Duration delay = ms1 * cappedRetry;
+        return delay;
+      };
+
+      Stopwatch dcRT = new Stopwatch();
+      return retry.start(dcNewFuture, retryDelay: dcDelay, runTime: dcRT)
+        .then((v) {
+          // dcFuture is coded to eventually succeed after maxI attempts, when
+          // the default retriesInfinite is the onError function.
+          expect(v, maxI);
+          expect(dcI, maxI);
+          // Multiple attempts should at least exceed the initial retry delay
+          // times the expected number of retries.
+          expect(dcRT.elapsed, greaterThan(ms1 * maxI));
+          // At least one delay should have exceeded the cap, so total
+          // elapsed time should definitely exceed that value (and then some).
+          expect(dcRT.elapsed, greaterThan(capAfter));
+          // cappedRetry should have stopped increasing (well) before msCapped
+          // retries.
+          expect(cappedRetry, lessThan(msCapped));
+        });
+    });
+  });
+}


### PR DESCRIPTION
A first attempt at adding retry.dart and its corresponding retry_test.dart to quiver-dart. Comments _very_ welcome.
