### PR TITLE
FakeAsync: wrap Futures returned to unittest

### DIFF
--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -193,7 +193,7 @@ main() {
         });
 
         test('should add event before advancing time', () {
-          return new FakeAsync().run((async) {
+          return new Future(() => new FakeAsync().run((async) {
             var controller = new StreamController();
             var ret = controller.stream.first.then((_) {
               expect(async.getClock(initialTime).now(), initialTime);
@@ -201,7 +201,7 @@ main() {
             controller.add(null);
             async.elapse(const Duration(minutes: 1));
             return ret;
-          });
+          }));
         });
 
         test('should increase negative duration timers to zero duration', () {
@@ -316,13 +316,8 @@ main() {
             expect(errors.first, new isInstanceOf<TimeoutException>());
             return controller.close();
           });
-
         });
-
       });
-
     });
-
   });
-
 }


### PR DESCRIPTION
to ensure any then/whenComplete/etc. called by unittest are not scheduled in FakeAsync's custom zone.
