### PR TITLE
Update documentation URL to dartdocs.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ libraries easier and more convenient, or adds additional functionality.
 
 ## Documentation
 
-API Docs can be found here: http://google.github.io/quiver-dart/
+API Docs can be found here: http://www.dartdocs.org/documentation/quiver/latest
 
 ## Installation
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,6 @@ authors:
 - John McDole <codefu@google.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
-documentation: http://google.github.io/quiver-dart/
 environment:
   sdk: '>=1.0.0'
 dependencies:


### PR DESCRIPTION
Fixes #180.
