### PR TITLE
Delegate toString to the underlying collections in the views returned by Multimaps

### DIFF
--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -440,6 +440,11 @@ class _WrappedIterable<K, V> implements Iterable<V> {
     return _delegate.toSet();
   }
 
+  String toString() {
+    _syncDelegate();
+    return _delegate.toString();
+  }
+
   Iterable<V> where(bool test(V element)) {
     _syncDelegate();
     return _delegate.where(test);


### PR DESCRIPTION
Before _Wrapped\* would only print "Instance of '_Wrapped*'" which is not as useful.
