### PR TITLE
all authors into pubspec.yaml; add missing contributors

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,7 +1,0 @@
-# Below is a list of people and organizations that have contributed
-# to the quiver project. Names should be added to the list like so:
-#
-#   Name/Organization <email address>
-
-Google Inc.
-Victor Berchet <victor@suumit.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,6 +9,8 @@ authors:
 - John McDole <codefu@google.com>
 - Matan Lurey <matanl@google.com>
 - Günter Zöchbauer <guenter@gzoechbauer.com>
+- Sean Eagan <seaneagan1@gmail.com>
+- Victor Berchet <victor@suumit.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:


### PR DESCRIPTION
Consolidate list of authors into pubspec.yaml and add missing contributors. Fixes #253.

/cc @seaneagan 