### PR TITLE
use enum TreeSearch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#### 0.21.5
+   * Change `TreeSearch` from `class` to `enum`.
+
 #### 0.21.4 - 2015-05-15
    * Add stats reporting for fake async tests. You can query the number of 
      pending microtasks and timers via `microtaskCount`, `periodicTimerCount`, 

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -70,25 +70,22 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
 /**
  * Controls the results for [TreeSet.searchNearest]()
  */
-class TreeSearch {
+enum TreeSearch {
 
   /**
-   * If result not found, always chose the smaler element
+   * If result not found, always chose the smaller element
    */
-  static const LESS_THAN = const TreeSearch._(1);
+  LESS_THAN,
 
   /**
    * If result not found, chose the nearest based on comparison
    */
-  static const NEAREST = const TreeSearch._(2);
+  NEAREST,
 
   /**
    * If result not found, always chose the greater element
    */
-  static const GREATER_THAN = const TreeSearch._(3);
-
-  final int _val;
-  const TreeSearch._(this._val);
+  GREATER_THAN
 }
 
 /**


### PR DESCRIPTION
Eliminates an unused field warning – and it's a good use of enum

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/quiver-dart/260)
<!-- Reviewable:end -->
