### PR TITLE
Deprecate FutureGroup, points folks to pkg/async

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### 0.22.0
    * Pre-1.8.0 SDKs are no longer supported.
    * Change `TreeSearch` from `class` to `enum`.
+   * Deprecated `FutureGroup`. Use the implementation in the
+     [async package](https://pub.dartlang.org/packages/async).
 
 #### 0.21.4 - 2015-05-15
    * Add stats reporting for fake async tests. You can query the number of 

--- a/lib/src/async/future_group.dart
+++ b/lib/src/async/future_group.dart
@@ -15,12 +15,16 @@
 part of quiver.async;
 
 /**
+ * DEPRECATED: Use a much more feature-rich `FutureGroup` from the
+ * [async package](https://pub.dartlang.org/packages/async).
+ *
  * A collection of [Future]s that signals when all added Futures complete. New
  * Futures can be added to the group as long as it hasn't completed.
  *
  * FutureGroup is useful for managing a set of async tasks that may spawn new
  * async tasks as they execute.
  */
+@Deprecated('Will be removed in 0.22.0')
 class FutureGroup<E> {
   static const _FINISHED = -1;
 

--- a/lib/testing/src/async/async.dart
+++ b/lib/testing/src/async/async.dart
@@ -20,7 +20,7 @@ part of quiver.testing.async;
  * A [Timer] implementation that stores its duration and callback for access
  * in tests.
  */
-@deprecated
+@Deprecated('Will be removed in 0.23.0')
 class FakeTimer implements Timer {
   Duration duration;
   var callback;


### PR DESCRIPTION
<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/google/quiver-dart/263)

<!-- Reviewable:end -->
