### PR TITLE
added a shortcut for creating an Optional from a nullable

### DIFF
--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -128,3 +128,9 @@ class Optional<T> {
         : 'Optional { value: ${_value} }';
   }
 }
+
+/*
+ * Returns a new Optional from a nullable value. Just a terse shortcut for a
+ * common use case.
+ */
+Optional optional(dynamic value) => new Optional.fromNullable(T value);


### PR DESCRIPTION
In general, Optional is used in places where normally we would just rely on null checking. For this reason, the most common use case is probably creating an object from a nullable, and so I add a shortcut to make this use case more terse.