### PR TITLE
Add LruSet implementation based on LruMap

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ false.
 
 `listsEqual`, `mapsEqual` and `setsEqual` check collections for equality.
 
-`LruMap` is a map that removes the least recently used item when a threshold
+`LruSet` and `LruMap` are collections that remove the least recently used item when a threshold
 length is exceeded.
 
 `Multimap` is an associative collection that maps keys to collections of

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -25,6 +25,7 @@ import 'package:quiver/iterables.dart';
 
 part 'src/collection/bimap.dart';
 part 'src/collection/lru_map.dart';
+part 'src/collection/lru_set.dart';
 part 'src/collection/multimap.dart';
 part 'src/collection/treeset.dart';
 part 'src/collection/delegates/iterable.dart';

--- a/lib/src/collection/lru_set.dart
+++ b/lib/src/collection/lru_set.dart
@@ -1,0 +1,107 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.collection;
+
+/**
+ * An implementation of a [Set] which has a maximum size and uses a (Least
+ * Recently Used)[http://en.wikipedia.org/wiki/Cache_algorithms#LRU] algorithm
+ * to remove items from the [Set] when the [maximumSize] is reached and new
+ * items are added.
+ *
+ * It is safe to access the iterator and contains method without affecting
+ * the "used" ordering - as well as using [forEach]. Other types of access,
+ * including lookup, promotes the key-value pair to the MRU position.
+ */
+abstract class LruSet<E> implements Set<E> {
+  /**
+   * Creates a [LruSet] instance with the default implementation.
+   */
+  factory LruSet({int maximumSize}) = LinkedLruHashSet;
+
+  /**
+   * Maximum size of the [Set]. If [length] exceeds this value at any time,
+   * n entries accessed the earliest are removed, where n is [length] -
+   * [maximumSize].
+   */
+  int maximumSize;
+}
+
+/**
+ * A linked hash-table based implementation of [LruSet].
+ */
+class LinkedLruHashSet<E> extends SetBase<E> implements LruSet<E> {
+  static const _DEFAULT_MAXIMUM_SIZE = 100;
+
+  final LruMap<E, bool> _entries;
+
+  /**
+   * Create a new LinkedLruHashSet with a [maximumSize].
+   */
+  factory LinkedLruHashSet({int maximumSize}) =>
+    new LinkedLruHashSet._fromMap(new LruMap<E, bool>(maximumSize: maximumSize));
+
+  LinkedLruHashSet._fromMap(this._entries);
+
+  /**
+   * If [element] already exists, promotes it to the MRU position.
+   *
+   * Otherwise, adds [element] to the MRU position.
+   * If [length] exceeds [maximumSize] while adding, removes the LRU position.
+   */
+  @override
+  bool add(E element) {
+    bool wasPresent = _entries.containsKey(element);
+    _entries[element] = true;
+    return !wasPresent;
+  }
+
+  @override contains(E element) => _entries.containsKey(element);
+
+  /**
+   * If an object equal to object is in the set, return it.
+   *
+   * Checks if there is an object in the set that is equal to object.
+   * If so, that object is returned, otherwise returns null.
+   *
+   * The [element] will be promoted to the 'Most Recently Used' position.
+   */
+  @override lookup(E element) {
+    bool wasPresent = _entries.containsKey(element);
+    if(wasPresent) {
+      _entries[element] = true;
+    }
+    return wasPresent;
+  }
+
+  @override
+  bool remove(E element) => _entries.remove(element) != null;
+
+  @override
+  Iterator<E> get iterator => _entries.keys.iterator;
+
+  @override
+  int get length => _entries.length;
+
+  @override
+  int get maximumSize => _entries.maximumSize;
+
+  @override
+  void set maximumSize(int maximumSize) {
+    _entries.maximumSize = maximumSize;
+  }
+
+  @override
+  Set<E> toSet() => _entries.keys.toSet();
+}

--- a/lib/src/collection/lru_set.dart
+++ b/lib/src/collection/lru_set.dart
@@ -44,13 +44,14 @@ abstract class LruSet<E> implements Set<E> {
 class LinkedLruHashSet<E> extends SetBase<E> implements LruSet<E> {
   static const _DEFAULT_MAXIMUM_SIZE = 100;
 
-  final LruMap<E, bool> _entries;
+  final LinkedLruHashMap<E, bool> _entries;
 
   /**
    * Create a new LinkedLruHashSet with a [maximumSize].
    */
   factory LinkedLruHashSet({int maximumSize}) =>
-    new LinkedLruHashSet._fromMap(new LruMap<E, bool>(maximumSize: maximumSize));
+    new LinkedLruHashSet._fromMap(
+      new LinkedLruHashMap<E, bool>(maximumSize: maximumSize));
 
   LinkedLruHashSet._fromMap(this._entries);
 
@@ -83,6 +84,23 @@ class LinkedLruHashSet<E> extends SetBase<E> implements LruSet<E> {
       _entries[element] = true;
     }
     return wasPresent;
+  }
+
+  @override
+  E get first {
+    if(isEmpty) throw new StateError("Set is empty");
+    return _entries._head.key;
+  }
+
+  /**
+   * Returns the last element.
+   *
+   * This operation is performed in constant time.
+   */
+  @override
+  E get last {
+    if(isEmpty) throw new StateError("Set is empty");
+    return _entries._tail.key;
   }
 
   @override

--- a/test/collection/lru_set_test.dart
+++ b/test/collection/lru_set_test.dart
@@ -1,0 +1,218 @@
+// Copyright 2014 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.collection.lru_map_test;
+
+import 'package:quiver/collection.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('LruSet', () {
+    /// A set that will be initialize by individual tests.
+    LruSet<String> lruSet;
+
+    test('the length property reflects how many elements are in the set', () {
+      lruSet = new LruSet();
+      expect(lruSet, hasLength(0));
+
+      lruSet.addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+      expect(lruSet, hasLength(3));
+    });
+
+    test('accessing elements causes them to be promoted', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      lruSet.lookup('B');
+
+      // In a LRU cache, the first element is the one that will be removed if the
+      // capacity is reached, so adding elements to the end is considered to be a
+      // 'promotion'.
+      expect(lruSet.toList(), ['B', 'C', 'A']);
+    });
+
+    test('new elements are added at the beginning', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      lruSet.add('D');
+      expect(lruSet.toList(), ['D', 'C', 'B', 'A']);
+    });
+
+    test('setting values on existing elements works, and promotes the key', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      lruSet.add('B');
+      expect(lruSet.toList(), ['B', 'C', 'A']);
+    });
+
+    test('the least recently used element is evicted when capacity hit', () {
+      lruSet = new LruSet(maximumSize: 3)..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      lruSet.add('D');
+      expect(lruSet.toList(), ['D', 'C', 'B']);
+    });
+
+    test('setting maximum size evicts elements until the size is met', () {
+      lruSet = new LruSet(maximumSize: 5)..addAll(new Set.from([
+        'A',
+        'B',
+        'C',
+        'D',
+        'E'
+      ]));
+
+      lruSet.maximumSize = 3;
+      expect(lruSet.toList(), ['E', 'D', 'C']);
+    });
+
+    test('accessing the iterator does not affect position', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      Iterator iterator = lruSet.iterator;
+      while(iterator.moveNext());
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
+    test('clearing removes all elements', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.isNotEmpty, isTrue);
+
+      lruSet.clear();
+
+      expect(lruSet.isEmpty, isTrue);
+    });
+
+    test('`contains` returns true if the element is in the set', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.contains('A'), isTrue);
+      expect(lruSet.contains('D'), isFalse);
+    });
+
+    test('`forEach` returns all items without modifying order', () {
+      final elements = [];
+
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+
+      lruSet.forEach((element) {
+        elements.add(element);
+      });
+
+      expect(elements, ['C', 'B', 'A']);
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
+    group('`remove`', () {
+      setUp(() {
+        lruSet = new LruSet()..addAll(new Set.from([
+          'A',
+          'B',
+          'C'
+        ]));
+      });
+
+      test('returns the value associated with a key, if it exists', () {
+        expect(lruSet.remove('A'), true);
+      });
+
+      test('returns null if the provided element does not exist', () {
+        expect(lruSet.remove('D'), false);
+      });
+
+      test('can remove the head', () {
+        lruSet.remove('C');
+        expect(lruSet.toList(), ['B', 'A']);
+      });
+
+      test('can remove the tail', () {
+        lruSet.remove('A');
+        expect(lruSet.toList(), ['C', 'B']);
+      });
+
+      test('can remove a middle entry', () {
+        lruSet.remove('B');
+        expect(lruSet.toList(), ['C', 'A']);
+      });
+    });
+
+    group('`add`', () {
+      setUp(() {
+        lruSet = new LruSet()..addAll(new Set.from([
+          'A',
+          'B',
+          'C'
+        ]));
+      });
+
+      test('adds an item if it does not exist, and moves it to the MRU', () {
+        expect(lruSet.add('D'), true);
+        expect(lruSet.toList(), ['D', 'C', 'B', 'A']);
+      });
+
+      test('does not add an item if it exists, but does promote it to MRU', () {
+        expect(lruSet.add('B'), false);
+        expect(lruSet.toList(), ['B', 'C', 'A']);
+      });
+
+      test('removes the LRU item if `maximumSize` exceeded', () {
+        lruSet.maximumSize = 3;
+        expect(lruSet.add('D'), true);
+        expect(lruSet.toList(), ['D', 'C', 'B']);
+      });
+    });
+  });
+}

--- a/test/collection/lru_set_test.dart
+++ b/test/collection/lru_set_test.dart
@@ -137,6 +137,27 @@ void main() {
       expect(lruSet.contains('D'), isFalse);
     });
 
+    test('`first` returns first element', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.first, 'C');
+    });
+
+    test('`last` returns last element and does not change order', () {
+      lruSet = new LruSet()..addAll(new Set.from([
+        'A',
+        'B',
+        'C'
+      ]));
+
+      expect(lruSet.last, 'A');
+      expect(lruSet.toList(), ['C', 'B', 'A']);
+    });
+
     test('`forEach` returns all items without modifying order', () {
       final elements = [];
 


### PR DESCRIPTION
This implementation internally just uses a LruMap to handle the LRU algorithm.

A full implementation can be found in #280.

Fixes #278 
