### PR TITLE
Add first and last getter to LinkedLruHashMap

### DIFF
--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -154,6 +154,10 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   @override
   Iterable<V> get values => _iterable().map((e) => e.value);
 
+  K get first => _head.key;
+
+  K get last => _tail.key;
+
   @override
   int get maximumSize => _maximumSize;
 


### PR DESCRIPTION
Even though `LinkedHashMap` does not have these explicit getters, I think they should be there because they are useful.

`LinkedHashSet` does have the getters (I think `LinkedHashMap` does not have them, because it cannot import the `Iterable` interface without the need for a new `Pair` class). Every `Linked*` class should expose first and last. I could make a PR for `LinkedHashMap` too..

I considered the names `firstKey` and `lastKey`. Still not entirely sure about the names, though.

I think I will also add the getters to the LruMap interface.