### PR TITLE
Add isNotEmpty method to strings.

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -28,7 +28,7 @@ bool isEmpty(String s) => s == null || s.isEmpty;
 /**
  * Returns [true] if [s] is a not empty string.
  */
-bool isEmpty(String s) => s != null && s.isNotEmpty;
+bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 
 /**
  * Returns a string with characters from the given [s] in reverse order.

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -26,6 +26,11 @@ bool isBlank(String s) => s == null || s.trim().isEmpty;
 bool isEmpty(String s) => s == null || s.isEmpty;
 
 /**
+ * Returns [true] if [s] is a not empty string.
+ */
+bool isEmpty(String s) => s != null && s.isNotEmpty;
+
+/**
  * Returns a string with characters from the given [s] in reverse order.
  */
 String flip(String s) {

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -48,7 +48,7 @@ main() {
     });
   });
 
-  group('isNonEmpty', () {
+  group('isNotEmpty', () {
     test('should consider null to be empty', () {
       expect(isNotEmpty(null), isFalse);
     });

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -15,7 +15,7 @@
 library quiver.strings;
 
 import 'package:quiver/strings.dart';
-import 'package:test/test.dart' hide isEmpty;
+import 'package:test/test.dart' hide isEmpty, isNotEmpty;
 
 main() {
   group('isBlank', () {

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -48,6 +48,21 @@ main() {
     });
   });
 
+  group('isNonEmpty', () {
+    test('should consider null to be empty', () {
+      expect(isNotEmpty(null), isFalse);
+    });
+    test('should consider the empty string to be empty', () {
+      expect(isNotEmpty(''), isFalse);
+    });
+    test('should consider whitespace string to be not empty', () {
+      expect(isNotEmpty(' '), isTrue);
+    });
+    test('should consider non-whitespace string to be not empty', () {
+      expect(isNotEmpty('hello'), isTrue);
+    });
+  });
+
   group('isDigit', () {
     test('should return true for standard digits', () {
       for (var i = 0; i <= 9; i++) {


### PR DESCRIPTION
Dart convention is to provide both methods in most interfaces,
so it is better dart style to have:

    if(isNotEmpty(nullableString))

than:

    if(!isEmpty(nullableString))