### PR TITLE
Make Optional implement Iterable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ packages
 pubspec.lock
 build/
 .pub
+.packages
 
 # IDE
 .project

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -16,6 +16,7 @@
  * Simple code with broad use cases.
  */
 library quiver.core;
+import 'dart:collection';
 
 part 'src/core/hash.dart';
 part 'src/core/optional.dart';

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -21,7 +21,7 @@ part of quiver.core;
  * values to be null. It signals that a value is not required and provides
  * convenience methods for dealing with the absent case.
  */
-class Optional<T> {
+class Optional<T> extends IterableBase<T> {
   final T _value;
 
   /**
@@ -111,6 +111,10 @@ class Optional<T> {
         ? new Optional.absent()
         : new Optional.of(transformer(_value));
   }
+
+  @override
+  Iterator<T> get iterator =>
+    isPresent ? <T>[_value].iterator : new Iterable<T>.empty().iterator;
 
   /**
    * Delegates to the underlying [value] hashCode.

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -70,25 +70,29 @@ main() {
     test('transform should return transformed value or absent', () {
       expect(new Optional<int>.fromNullable(7).transform((a) => a + 1),
           equals(new Optional<int>.of(8)));
-      expect(new Optional<int>.fromNullable(null)
-          .transform((a) => a + 1).isPresent, isFalse);
+      expect(
+          new Optional<int>.fromNullable(null)
+              .transform((a) => a + 1)
+              .isPresent,
+          isFalse);
     });
 
     test('hashCode should allow optionals to be in hash sets', () {
-      expect(new Set.from([
-        new Optional<int>.of(7),
-        new Optional<int>.of(8),
-        new Optional<int>.absent()
-      ]), equals(new Set.from([
-        new Optional<int>.of(7),
-        new Optional<int>.of(8),
-        new Optional<int>.absent()
-      ])));
-      expect(new Set.from([
-        new Optional<int>.of(7),
-        new Optional<int>.of(8)
-      ]), isNot(equals(
-          new Set.from([new Optional<int>.of(7), new Optional<int>.of(9)]))));
+      expect(
+          new Set.from([
+            new Optional<int>.of(7),
+            new Optional<int>.of(8),
+            new Optional<int>.absent()
+          ]),
+          equals(new Set.from([
+            new Optional<int>.of(7),
+            new Optional<int>.of(8),
+            new Optional<int>.absent()
+          ])));
+      expect(
+          new Set.from([new Optional<int>.of(7), new Optional<int>.of(8)]),
+          isNot(equals(new Set.from(
+              [new Optional<int>.of(7), new Optional<int>.of(9)]))));
     });
 
     test('== should compare by value', () {
@@ -105,6 +109,23 @@ main() {
           new Optional<int>.of(7).toString(), equals('Optional { value: 7 }'));
       expect(new Optional<int>.fromNullable(null).toString(),
           equals('Optional { absent }'));
+    });
+
+    test('length when absent should return 0', () {
+      expect(const Optional.absent().length, equals(0));
+    });
+
+    test('length when present should return 1', () {
+      expect(new Optional<int>.of(1).length, equals(1));
+    });
+
+    test('expand should behave as equivalent iterable', () {
+      final optionals = <Optional<int>>[
+        new Optional<int>.of(1),
+        const Optional.absent(),
+        new Optional<int>.of(2)
+      ].expand((i) => i);
+      expect(optionals, orderedEquals([1, 2]));
     });
   });
 }


### PR DESCRIPTION
Implementing `Iterable` allows an `Optional`s to be passed into anything expecting an `Iterable` and facilitates common cases like

```
final optionals = <Optional<int>>[
        new Optional<int>.of(1),
        const Optional.absent(),
        new Optional<int>.of(2)
      ];
final ints = optionals.expand((i) => i); // (1, 2)
```