### PR TITLE
Return default Map type from asMap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 0.23.0
+   * `Multimap.asMap` now returns an instance of the default Map type,
+     `LinkedHashMap`.
+   * Eliminate strong mode errors and warnings.
+
 #### 0.22.0 - 2015-04-21
    * BREAKING CHANGE: `streams` and `async` libraries have been [merged](https://github.com/google/quiver-dart/commit/671f1bc75742b4393e203c9520a3bf1e031967dc) into one `async` library
    * BREAKING CHANGE: Pre-1.8.0 SDKs are no longer supported.

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -165,7 +165,7 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     }
   }
 
-  final Map<K, C> _map = new HashMap();
+  final Map<K, C> _map = <K, C>{};
 
   C _create();
   void _add(C iterable, V value);


### PR DESCRIPTION
The core Map factory constructor/Map literal creates a LinkedHashMap.
For consistency with the core lib, do the same in Multimap.
