### PR TITLE
Add retry function to async library

### DIFF
--- a/lib/async.dart
+++ b/lib/async.dart
@@ -20,13 +20,14 @@ import 'package:quiver/iterables.dart' show IndexedValue;
 import 'package:quiver/time.dart';
 
 part 'src/async/collect.dart';
-part 'src/async/countdown_timer.dart';
 part 'src/async/concat.dart';
+part 'src/async/countdown_timer.dart';
 part 'src/async/enumerate.dart';
 part 'src/async/future_group.dart';
 part 'src/async/future_stream.dart';
 part 'src/async/iteration.dart';
 part 'src/async/metronome.dart';
+part 'src/async/retry.dart';
 part 'src/async/stream_buffer.dart';
 part 'src/async/stream_router.dart';
 

--- a/lib/src/async/retry.dart
+++ b/lib/src/async/retry.dart
@@ -1,0 +1,36 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+part of quiver.async;
+
+const _defaultInterval = const Duration(milliseconds: 100);
+const _defaultTimeout = const Duration(seconds: 60);
+
+/// Runs an asynchronous [task] repeatedly until it succeeds or [timeout] is
+/// reached.
+///
+/// Waits [interval] to perform the retry after a failed attempt.
+Future/*<T>*/ retry/*<T>*/(Future/*<T>*/ task(),
+    {Duration interval: _defaultInterval,
+    Duration timeout: _defaultTimeout}) async {
+  var end = new DateTime.now().add(timeout);
+  while (true) {
+    try {
+      return await task();
+    } catch (error) {
+      if (new DateTime.now().isAfter(end)) rethrow;
+      await new Future.delayed(interval);
+    }
+  }
+}

--- a/lib/src/async/retry.dart
+++ b/lib/src/async/retry.dart
@@ -39,7 +39,7 @@ Future/*<T>*/ retry/*<T>*/(Future/*<T>*/ task(),
       throw lastCaught;
     } catch (error) {
       if (new DateTime.now().isAfter(end)) rethrow;
-      await new Future.delayed(interval);
+      await new Future<Null>.delayed(interval);
     }
   }
 }

--- a/lib/src/async/retry.dart
+++ b/lib/src/async/retry.dart
@@ -33,10 +33,11 @@ Future/*<T>*/ retry/*<T>*/(Future/*<T>*/ task(),
   dynamic lastCaught;
   while (true) {
     try {
-      return await task().timeout(end.difference(new DateTime.now()));
-    } on TimeoutException catch (_) {
-      if (lastCaught == null) rethrow;
-      throw lastCaught;
+      return await task().timeout(end.difference(new DateTime.now()),
+          onTimeout: () {
+        throw lastCaught ??
+            new TimeoutException('Timeout during first task run.');
+      });
     } catch (error) {
       lastCaught = error;
       if (new DateTime.now().isAfter(end)) rethrow;

--- a/lib/src/async/retry.dart
+++ b/lib/src/async/retry.dart
@@ -38,6 +38,7 @@ Future/*<T>*/ retry/*<T>*/(Future/*<T>*/ task(),
       if (lastCaught == null) rethrow;
       throw lastCaught;
     } catch (error) {
+      lastCaught = error;
       if (new DateTime.now().isAfter(end)) rethrow;
       await new Future<Null>.delayed(interval);
     }

--- a/test/async/all_tests.dart
+++ b/test/async/all_tests.dart
@@ -23,6 +23,7 @@ import 'future_group_test.dart' as future_group;
 import 'future_stream_test.dart' as future_stream;
 import 'iteration_test.dart' as iteration;
 import 'metronome_test.dart' as metronome;
+import 'retry_test.dart' as retry;
 import 'stream_buffer_test.dart' as stream_buffer;
 import 'stream_router_test.dart' as stream_router;
 
@@ -34,8 +35,9 @@ main() {
   enumerate.main();
   future_group.main();
   future_stream.main();
-  metronome.main();
   iteration.main();
+  metronome.main();
+  retry.main();
   stream_buffer.main();
   stream_router.main();
 }

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -1,0 +1,50 @@
+// Copyright 2016 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+library quiver.async.retry_test;
+
+import 'package:test/test.dart';
+import 'package:quiver/async.dart';
+
+void main() {
+  group('retry', () {
+    test('should run more than once on exception', () async {
+      var runCount = 0;
+      var task = () async {
+        runCount++;
+        if (runCount < 2) {
+          throw '';
+        }
+      };
+      await retry(task, interval: const Duration(milliseconds: 1));
+      expect(runCount, 2);
+    });
+  });
+
+  test('should return the result of the task', () async {
+    var task = () async => 'result';
+    expect(await retry(task), 'result');
+  });
+
+  test('should rethrow after timeout', () async {
+    var task = () async {
+      throw 'error';
+    };
+    expect(
+        retry(task,
+            interval: const Duration(milliseconds: 1),
+            timeout: const Duration(milliseconds: 1)),
+        throwsA(equals('error')));
+  });
+}

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -14,6 +14,8 @@
 
 library quiver.async.retry_test;
 
+import 'dart:async';
+
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
@@ -36,7 +38,7 @@ void main() {
       expect(await retry(task), 'result');
     });
 
-    test('should rethrow after timeout', () async {
+    test('should rethrow the actual exception after timeout', () async {
       var task = () async {
         throw 'error';
       };
@@ -45,6 +47,13 @@ void main() {
               interval: const Duration(milliseconds: 1),
               timeout: const Duration(milliseconds: 1)),
           throwsA(equals('error')));
+    });
+
+    test('should timeout long tasks', () async {
+      var task = () => new Completer().future;
+
+      expect(retry(task, timeout: const Duration(milliseconds: 100)),
+          throwsA(new isInstanceOf<TimeoutException>()));
     });
   });
 }

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -30,21 +30,21 @@ void main() {
       await retry(task, interval: const Duration(milliseconds: 1));
       expect(runCount, 2);
     });
-  });
 
-  test('should return the result of the task', () async {
-    var task = () async => 'result';
-    expect(await retry(task), 'result');
-  });
+    test('should return the result of the task', () async {
+      var task = () async => 'result';
+      expect(await retry(task), 'result');
+    });
 
-  test('should rethrow after timeout', () async {
-    var task = () async {
-      throw 'error';
-    };
-    expect(
-        retry(task,
-            interval: const Duration(milliseconds: 1),
-            timeout: const Duration(milliseconds: 1)),
-        throwsA(equals('error')));
+    test('should rethrow after timeout', () async {
+      var task = () async {
+        throw 'error';
+      };
+      expect(
+          retry(task,
+              interval: const Duration(milliseconds: 1),
+              timeout: const Duration(milliseconds: 1)),
+          throwsA(equals('error')));
+    });
   });
 }

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -58,5 +58,19 @@ void main() {
       expect(retry(task, timeout: const Duration(milliseconds: 100)),
           throwsA(new isInstanceOf<TimeoutException>()));
     });
+
+    test('Reruns task if it throws a TimeoutException before the retry timeout',
+        () async {
+      var runCount = 0;
+      var task = () async {
+        runCount++;
+        if (runCount < 2) {
+          throw new TimeoutException('Test timeout');
+        }
+      };
+
+      await retry(task, interval: const Duration(milliseconds: 1));
+      expect(runCount, 2);
+    });
   });
 }

--- a/test/async/retry_test.dart
+++ b/test/async/retry_test.dart
@@ -39,13 +39,16 @@ void main() {
     });
 
     test('should rethrow the actual exception after timeout', () async {
+      var runCount = 0;
       var task = () async {
-        throw 'error';
+        runCount++;
+        if (runCount < 2) throw 'error';
+        return new Completer().future;
       };
       expect(
           retry(task,
               interval: const Duration(milliseconds: 1),
-              timeout: const Duration(milliseconds: 1)),
+              timeout: const Duration(milliseconds: 100)),
           throwsA(equals('error')));
     });
 


### PR DESCRIPTION
- Add retry.dart with a single top level method `retry`
- Add retry_test.dart with tests for the the new method
- Sort `part` declarations in async.dart
- Sort subtest calls in async/all_tests.dart
