### PR TITLE
Update Set.difference to take Set<Object>

### DIFF
--- a/lib/src/collection/delegates/set.dart
+++ b/lib/src/collection/delegates/set.dart
@@ -38,7 +38,7 @@ abstract class DelegatingSet<E> extends DelegatingIterable<E>
 
   bool containsAll(Iterable<Object> other) => delegate.containsAll(other);
 
-  Set<E> difference(Set<E> other) => delegate.difference(other);
+  Set<E> difference(Set<Object> other) => delegate.difference(other);
 
   Set<E> intersection(Set<Object> other) => delegate.intersection(other);
 

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -701,7 +701,7 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
     return _delegate.containsAll(other);
   }
 
-  Set<V> difference(Set<V> other) {
+  Set<V> difference(Set<Object> other) {
     _syncDelegate();
     return _delegate.difference(other);
   }

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -865,7 +865,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   /**
    * See [Set.difference]
    */
-  Set<V> difference(Set<V> other) {
+  Set<V> difference(Set<Object> other) {
     TreeSet<V> set = new TreeSet(comparator: comparator);
 
     if (other is TreeSet) {


### PR DESCRIPTION
The signature of Set.difference has changed tin 1.21 to accept Set<Object>.

@cbracken 