### PR TITLE
Deprecate FutureGroup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### Unreleased
+   * Deprecated: `FutureGroup`. Use the replacement in `package:async` which
+     requires a `close()` call to trigger auto-completion when the count of
+     pending tasks drops to 0.
+
 #### 0.24.0 - 2016-10-31
    * BREAKING CHANGE: eliminated deprecated `nullToEmpty`, `emptyToNull`.
    * Fix: Strong mode: As of Dart SDK 1.21.0, `Set.difference` takes a

--- a/lib/src/async/future_group.dart
+++ b/lib/src/async/future_group.dart
@@ -19,6 +19,11 @@ part of quiver.async;
 ///
 /// FutureGroup is useful for managing a set of async tasks that may spawn new
 /// async tasks as they execute.
+///
+/// DEPRECATED: use `FutureGroup` from `package:async`. Note that it requires a
+/// `close()` call before auto-completion will be triggered upon the count of
+/// pending tasks dropping to 0.
+@deprecated
 class FutureGroup<E> {
   static const _FINISHED = -1;
 


### PR DESCRIPTION
Users should migrate to FutureGroup in package:async instead. Note that
that version requires a call to close() before it will complete when the
count of pending tasks reaches 0. This allows for use-cases where tasks
continue to be added after all existing tasks have completed.