### PR TITLE
Deprecate repeat()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
    * Deprecated: `FutureGroup`. Use the replacement in `package:async` which
      requires a `close()` call to trigger auto-completion when the count of
      pending tasks drops to 0.
+   * Deprecated: `repeat` in the `strings` library. Use the `*` operator on
+     the String class.
 
 #### 0.24.0 - 2016-10-31
    * BREAKING CHANGE: eliminated deprecated `nullToEmpty`, `emptyToNull`.

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -41,6 +41,9 @@ String flip(String s) {
 ///
 /// If [times] is negative, returns the [flip]ped string repeated given number
 /// of [times].
+///
+/// DEPRECATED: use the `*` operator on [String].
+@deprecated
 String repeat(String s, int times) {
   if (s == null || s == '') return s;
   if (times < 0) {


### PR DESCRIPTION
Users should migrate to the * operator on the String class.