### PR TITLE
Require Dart SDK >= 1.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 #### Unreleased
+   * BREAKING CHANGE: minimum SDK constraint increased to 1.9.0. This allows
+     use of async-await in Quiver.
    * BREAKING CHANGE: eliminated deprecated `FakeTimer`.
    * Deprecated: `FutureGroup`. Use the replacement in `package:async` which
      requires a `close()` call to trigger auto-completion when the count of

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ authors:
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:
-  sdk: '>=1.8.0 <2.0.0'
+  sdk: '>=1.9.0 <2.0.0'
 dependencies:
   matcher: '>=0.10.0 <0.13.0'
 dev_dependencies:


### PR DESCRIPTION
Allows use of async-await in Quiver.