### PR TITLE
Make enumerate a generic function

### DIFF
--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -16,8 +16,8 @@ part of quiver.iterables;
 
 /// Returns an [Iterable] of [IndexedValue]s where the nth value holds the nth
 /// element of [iterable] and its index.
-Iterable<IndexedValue> enumerate(Iterable iterable) =>
-    new EnumerateIterable(iterable);
+Iterable<IndexedValue<E>> enumerate<E>(Iterable iterable) =>
+    new EnumerateIterable<E>(iterable);
 
 class IndexedValue<V> {
   final int index;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ authors:
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:
-  sdk: '>=1.9.0 <2.0.0'
+  sdk: '>=1.21.0 <2.0.0'
 dependencies:
   matcher: '>=0.10.0 <0.13.0'
 dev_dependencies:


### PR DESCRIPTION
This pull request makes `enumerate()` a generic function and increases minimum Dart SDK version to match version of Dart when generic functions were introduced.