### PR TITLE
Add method generics

### DIFF
--- a/lib/check.dart
+++ b/lib/check.dart
@@ -58,7 +58,7 @@ int checkListIndex(int index, int size, {message}) {
 
 /// Throws an [ArgumentError] if the given [reference] is `null`. Otherwise,
 /// returns the [reference] parameter.
-dynamic/*=T*/ checkNotNull/*<T>*/(/*=T*/ reference, {message}) {
+T checkNotNull<T>(T reference, {message}) {
   if (reference == null) {
     throw new ArgumentError(_resolveMessage(message, 'null pointer'));
   }

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -32,7 +32,7 @@ part of quiver.async;
 ///     var futureOfStream = getResource().then((resource) => resource.stream);
 ///     return new FutureStream(futureOfStream);
 class FutureStream<T> extends Stream<T> {
-  static/*=T*/ _identity/*<T>*/(/*=T*/ t) => t;
+  static T _identity<T>(T t) => t;
 
   Future<Stream<T>> _future;
   StreamController<T> _controller;

--- a/lib/src/collection/delegates/iterable.dart
+++ b/lib/src/collection/delegates/iterable.dart
@@ -35,7 +35,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
 
   bool every(bool test(E element)) => delegate.every(test);
 
-  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(E element)) =>
+  Iterable<T> expand<T>(Iterable<T> f(E element)) =>
       delegate.expand(f);
 
   E get first => delegate.first;
@@ -43,8 +43,8 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E firstWhere(bool test(E element), {E orElse()}) =>
       delegate.firstWhere(test, orElse: orElse);
 
-  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
-          dynamic/*=T*/ combine(var/*=T*/ previousValue, E element)) =>
+  T fold<T>(T initialValue,
+          T combine(T previousValue, E element)) =>
       delegate.fold(initialValue, combine);
 
   void forEach(void f(E element)) => delegate.forEach(f);
@@ -64,7 +64,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
 
   int get length => delegate.length;
 
-  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(E e)) => delegate.map(f);
+  Iterable<T> map<T>(T f(E e)) => delegate.map(f);
 
   E reduce(E combine(E value, E element)) => delegate.reduce(combine);
 

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -97,7 +97,7 @@ abstract class Multimap<K, V> {
 /// Abstract base class for multimap implementations.
 abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     implements Multimap<K, V> {
-  static/*=T*/ _id/*<T>*/(/*=T*/ x) => x;
+  static T _id<T>(T x) => x;
 
   _BaseMultimap();
 
@@ -335,7 +335,7 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     return _delegate.every(test);
   }
 
-  Iterable/*<T>*/ expand/*<T>*/(Iterable/*<T>*/ f(V element)) {
+  Iterable<T> expand<T>(Iterable<T> f(V element)) {
     _syncDelegate();
     return _delegate.expand(f);
   }
@@ -350,8 +350,8 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     return _delegate.firstWhere(test, orElse: orElse);
   }
 
-  dynamic/*=T*/ fold/*<T>*/(var/*=T*/ initialValue,
-      dynamic/*=T*/ combine(var/*=T*/ previousValue, V element)) {
+  T fold<T>(T initialValue,
+      T combine(T previousValue, V element)) {
     _syncDelegate();
     return _delegate.fold(initialValue, combine);
   }
@@ -396,7 +396,7 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     return _delegate.length;
   }
 
-  Iterable/*<T>*/ map/*<T>*/(/*=T*/ f(V element)) {
+  Iterable<T> map<T>(T f(V element)) {
     _syncDelegate();
     return _delegate.map(f);
   }

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -84,8 +84,7 @@ class Optional<T> extends IterableBase<T> {
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
-  Optional/*=Optional<S>*/ transform/*<S>*/(
-      dynamic/*=S*/ transformer(T value)) {
+  Optional<S> transform<S>(S transformer(T value)) {
     return _value == null
         ? new Optional.absent()
         : new Optional.of(transformer(_value));

--- a/lib/src/iterables/concat.dart
+++ b/lib/src/iterables/concat.dart
@@ -17,5 +17,5 @@ part of quiver.iterables;
 /// Returns the concatentation of the input iterables.
 ///
 /// The returned iterable is a lazily-evaluated view on the input iterables.
-Iterable/*<T>*/ concat/*<T>*/(Iterable<Iterable/*<T>*/ > iterables) =>
+Iterable<T> concat<T>(Iterable<Iterable<T>> iterables) =>
     iterables.expand((x) => x);

--- a/lib/src/iterables/cycle.dart
+++ b/lib/src/iterables/cycle.dart
@@ -16,8 +16,7 @@ part of quiver.iterables;
 
 /// Returns an [Iterable] that infinitely cycles through the elements of
 /// [iterable]. If [iterable] is empty, the returned Iterable will also be empty.
-Iterable/*<T>*/ cycle/*<T>*/(Iterable/*<T>*/ iterable) =>
-    new _Cycle/*<T>*/(iterable);
+Iterable<T> cycle<T>(Iterable<T> iterable) => new _Cycle<T>(iterable);
 
 class _Cycle<T> extends InfiniteIterable<T> {
   final Iterable<T> _iterable;

--- a/lib/src/iterables/infinite_iterable.dart
+++ b/lib/src/iterables/infinite_iterable.dart
@@ -30,8 +30,7 @@ abstract class InfiniteIterable<T> extends IterableBase<T> {
 
   bool every(bool f(T element)) => throw new UnsupportedError('every');
 
-  bool/*=T1*/ fold/*<T1>*/(var/*=T1*/ initialValue,
-          dynamic/*=T1*/ combine(var/*=T1*/ previousValue, T element)) =>
+  T1 fold<T1>(T1 initialValue, T1 combine(T1 previousValue, T element)) =>
       throw new UnsupportedError('fold');
 
   void forEach(void f(T element)) => throw new UnsupportedError('forEach');


### PR DESCRIPTION
As of Dart SDK 1.21.0 method generics are supported. Behaviour defaults
to dynamic in the VM and dart2js. DDC reifies them.