### PR TITLE
StreamBuffer<T> now implements StreamConsumer<T>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
    * BREAKING CHANGE: minimum SDK constraint increased to 1.21.0. This allows
      use of async-await and generic function in Quiver.
    * BREAKING CHANGE: eliminated deprecated `FakeTimer`.
+   * BREAKING CHANGE: `StreamBuffer<T>` now implements `StreamConsumer<T>` as
+     opposed to `StreamConsumer<T|List<T>>`.
    * Deprecated: `FutureGroup`. Use the replacement in `package:async` which
      requires a `close()` call to trigger auto-completion when the count of
      pending tasks drops to 0.

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -42,12 +42,12 @@ class UnderflowError extends Error {
 ///
 /// Throws [UnderflowError] if [throwOnError] is true. Useful for unexpected
 /// [Socket] disconnects.
-class StreamBuffer<T> implements StreamConsumer<dynamic /*T|List<T>*/ > {
-  List _chunks = [];
+class StreamBuffer<T> implements StreamConsumer<T> {
+  List<T> _chunks = [];
   int _offset = 0;
   int _counter = 0; // sum(_chunks[*].length) - _offset
   List<_ReaderInWaiting<List<T>>> _readers = [];
-  StreamSubscription<dynamic /*T|List<T>*/ > _sub;
+  StreamSubscription<T> _sub;
   Completer _streamDone;
 
   final bool _throwOnError;
@@ -93,13 +93,13 @@ class StreamBuffer<T> implements StreamConsumer<dynamic /*T|List<T>*/ > {
         ret.setRange(follower, follower + subsize,
             (chunk as List<T>).getRange(_offset, _offset + subsize));
       } else {
-        ret[follower] = chunk as T;
+        ret[follower] = chunk;
       }
       follower += subsize;
       _offset += subsize;
       _counter -= subsize;
       leftToRead -= subsize;
-      if (chunk is! List || _offset >= chunk.length) {
+      if (chunk is! List || _offset >= (chunk as List).length) {
         _offset = 0;
         _chunks.removeAt(0);
       }
@@ -129,7 +129,7 @@ class StreamBuffer<T> implements StreamConsumer<dynamic /*T|List<T>*/ > {
   }
 
   @override
-  Future addStream(Stream<dynamic /*T|List<T>*/ > stream) {
+  Future addStream(Stream<T> stream) {
     var lastStream = _currentStream == null ? stream : _currentStream;
     if (_sub != null) {
       _sub.cancel();

--- a/test/async/stream_buffer_test.dart
+++ b/test/async/stream_buffer_test.dart
@@ -21,7 +21,7 @@ import 'package:quiver/async.dart';
 void main() {
   group("StreamBuffer", () {
     test("returns orderly overlaps", () {
-      StreamBuffer<int> buf = new StreamBuffer();
+      StreamBuffer<List<int>> buf = new StreamBuffer();
       new Stream.fromIterable([
         [1],
         [2, 3, 4],
@@ -37,7 +37,7 @@ void main() {
     });
 
     test("respects pausing of stream", () {
-      StreamBuffer<int> buf = new StreamBuffer()..limit = 2;
+      StreamBuffer<List<int>> buf = new StreamBuffer()..limit = 2;
       new Stream.fromIterable([
         [1],
         [2],
@@ -54,7 +54,7 @@ void main() {
     });
 
     test("throws when reading too much", () {
-      StreamBuffer<int> buf = new StreamBuffer()..limit = 1;
+      StreamBuffer<List<int>> buf = new StreamBuffer()..limit = 1;
       new Stream.fromIterable([
         [1],
         [2]


### PR DESCRIPTION
Previously, it implemented StreamConsumer<T|List<T>>. For strong-mode
compatibility, we no longer support the union type.