### PR TITLE
Minor updates to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ the process as smooth as possible, we request the following:
      (see above) before sending your pull request. It's quick, we promise!
    * Have test cases for your changes and ensure that the existing ones pass in
      checked mode.
-   * Run your changes through `dartformat`. Follow the installation instructions
+   * Run your changes through `dartfmt`. Follow the installation instructions
      in the [dart_style](https://github.com/dart-lang/dart_style) README for
      more info.
    * Squash your commits into a single commit with a good description. You can
@@ -27,5 +27,7 @@ the process as smooth as possible, we request the following:
      Atlassian's
      [tutorial](https://www.atlassian.com/git/tutorials/rewriting-history).
    * During code review, go ahead and pile up commits addressing review
-     comments. Once you get an LGTM (looks good to me) on the review, we'll ask
-     you to squash your commits one last time, then we'll be good to merge!
+     comments. Once you get an LGTM (looks good to me) on the review, we'll
+     squash your commits and merge!
+   * If you're not already listed as an author in `pubspec.yaml`, remember to
+     add yourself and claim your rightful place amongst the Quiverati.


### PR DESCRIPTION
* dartformat was renamed dartfmt... years ago.
* Authors no longer need to squash their own commits post-review, github
  now supports doing so via the web interface.
* Remind contributors to feel free to add themselves to the authors
  list.