### PR TITLE
added #indexOf to collection.dart

### DIFF
--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -78,13 +78,22 @@ bool setsEqual(Set a, Set b) {
   return a.containsAll(b);
 }
 
-/// Returns the index of the first item in [list] where [matcher] evaluates to
-/// true.
+/// Returns the index of the first item in [elements] where [predicate]
+/// evaluates to true.
 ///
-/// Returns -1 if there are no items where [matcher] evaluates to true.
-int indexOf<T>(List<T> list, bool matcher(T item)) {
-  for (var i = 0; i < list.length; i++) {
-    if (matcher(list[i])) return i;
+/// Returns -1 if there are no items where [predicate] evaluates to true.
+int indexOf<T>(Iterable<T> elements, bool predicate(T element)) {
+  if (elements is List) {
+    for (int i = 0; i < elements.length; i++) {
+      if (predicate(elements[i])) return i;
+    }
+    return -1;
+  }
+
+  int i = 0;
+  for (T element in elements) {
+    if (predicate(element)) return i;
+    i++;
   }
   return -1;
 }

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -77,3 +77,14 @@ bool setsEqual(Set a, Set b) {
 
   return a.containsAll(b);
 }
+
+/// Returns the index of the first item in [list] where [matcher] evaluates to
+/// true.
+///
+/// Returns -1 if there are no items where [matcher] evaluates to true.
+int indexOf<T>(List<T> list, bool matcher(T item)) {
+  for (var i = 0; i < list.length; i++) {
+    if (matcher(list[i])) return i;
+  }
+  return -1;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ authors:
 - Günter Zöchbauer <guenter@gzoechbauer.com>
 - Sean Eagan <seaneagan1@gmail.com>
 - Victor Berchet <victor@suumit.com>
+- Wil Pirino <willyp@google.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -69,4 +69,17 @@ main() {
       expect(setsEqual(new Set(), new Set.from([1])), isFalse);
     });
   });
+
+  group('indexOf', () {
+    test('returns the first matching index', () {
+      expect(indexOf<int>([1, 12, 19, 20, 24], (n) => n % 2 == 0), 1);
+      expect(indexOf<String>(['a', 'b', 'a'], (s) => s == 'a'), 0);
+    });
+
+    test('returns -1 when there is no match', () {
+      expect(indexOf<int>([1, 3, 7], (n) => n % 2 == 0), -1);
+      expect(indexOf<String>(['a', 'b'], (s) => s == 'e'), -1);
+      expect(indexOf<bool>([], (n) => true), -1);
+    });
+  });
 }


### PR DESCRIPTION
Here is an example use case: cs/piper///depot/google3/ads/awapps2/shared/ad_group_criterion/lib/ad_group_criterion_mutate_helper.dart?l=38

There are many others.