### PR TITLE
Bump package:test minium version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,4 +19,4 @@ dependencies:
   matcher: '>=0.10.0 <0.13.0'
 dev_dependencies:
   path: '>=1.0.0 <2.0.0'
-  test: '>=0.12.0 <0.13.0'
+  test: '>=0.12.20 <=0.13.0'


### PR DESCRIPTION
Version 0.12.19 was incompatible with FakeAsync. Versions 0.12.*
excluding that version are compatible.