### PR TITLE
Improve reverse of string.

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -28,9 +28,9 @@ bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 String reverse(String s) {
   if (s == null || s == '') return s;
   StringBuffer sb = new StringBuffer();
-  var runes = s.runes;
-  for (int i = runes.length - 1; i >= 0; i--) {
-    sb.writeCharCode(runes.elementAt(i));
+  var runes = s.runes.iterator..reset(s.length);
+  while (runes.movePrevious()) {
+    sb.writeCharCode(runes.current);
   }
   return sb.toString();
 }


### PR DESCRIPTION
The existing implementation of reverse was quadratic in the string length.

It's still a very problematic method because it doesn't understand Unicode characters, only code points, so it will mis-attribute combining marks in a reversed string, e.g., reverse("niño") would become "õnin".