### PR TITLE
Don't use the result of `runGuarded`.

### DIFF
--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -181,7 +181,9 @@ class _FakeAsync implements FakeAsync {
     if (_zone == null) {
       _zone = Zone.current.fork(specification: _zoneSpec);
     }
-    return _zone.runGuarded(() => callback(this));
+    var result;
+    _zone.runGuarded(() { result = callback(this); });
+    return result;
   }
 
   Zone _zone;


### PR DESCRIPTION
When the function to `runGuarded` throws synchronously, then the uncaught-handler is invoked. Except for very rare cases, that handler can only return `null`. As such, it doesn't make sense to use the result of `runGuarded`. Future versions of the Zone API will thus make `runGuarded` a `void` function.