### PR TITLE
Eliminate deprecated strings.flip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 0.26.0-dev
+   * BREAKING CHANGE: eliminated deprecated `flip`. Replaced by `reverse` in
+     0.25.0.
+
 #### 0.25.0 - 2017-03-28
    * BREAKING CHANGE: minimum SDK constraint increased to 1.21.0. This allows
      use of async-await and generic function in Quiver.

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ used as a literal match inside of a RegExp.
 
 `compareIgnoreCase` compares two strings, ignoring case.
 
-`flip` flips the order of characters in a string.
+`reverse` reverses the order of characters in a string.
 
 `repeat` concatenates a string to itself a given number of times.
 

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -35,12 +35,6 @@ String reverse(String s) {
   return sb.toString();
 }
 
-/// Returns a string with characters from the given [s] in reverse order.
-///
-/// DEPRECATED: use [reverse] instead.
-@deprecated
-String flip(String s) => reverse(s);
-
 /// Concatenates [s] to itself a given number of [times]. Empty and null
 /// strings will always result in empty and null strings respectively no matter
 /// how many [times] they are [repeat]ed.


### PR DESCRIPTION
'flip' was renamed to 'reverse' in
08ed2e76f35fb05fa7ed8424f135cb61b970ea16.