### PR TITLE
Remove deprecated strings.repeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 #### 0.26.0-dev
    * BREAKING CHANGE: eliminated deprecated `flip`. Replaced by `reverse` in
      0.25.0.
+   * BREAKING CHANGE: eliminated deprecated `repeat`. Deprecated in 0.25.0.
+     Callers should use `String`'s `*` operator.
 
 #### 0.25.0 - 2017-03-28
    * BREAKING CHANGE: minimum SDK constraint increased to 1.21.0. This allows

--- a/README.md
+++ b/README.md
@@ -187,15 +187,13 @@ used as a literal match inside of a RegExp.
 
 `reverse` reverses the order of characters in a string.
 
-`repeat` concatenates a string to itself a given number of times.
-
 `loop` allows you to loop through characters in a string starting and ending at
 arbitrary indices. Out of bounds indices allow you to wrap around the string,
 supporting a number of use-cases, including:
 
   * Rotating: `loop('lohel', -3, 2) => 'hello'`
-  * Repeating, like `repeat`, but with better character-level control, e.g.:
-`loop('la ', 0, 8) => 'la la la'  // no tailing space`
+  * Repeating, like `String`'s `operator*`, but with better character-level
+    control, e.g.: `loop('la ', 0, 8) => 'la la la'  // no trailing space`
   * Tailing: `loop('/path/to/some/file.txt', -3) => 'txt'`
   * Reversing: `loop('top', 3, 0) => 'pot'`
 

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -35,25 +35,6 @@ String reverse(String s) {
   return sb.toString();
 }
 
-/// Concatenates [s] to itself a given number of [times]. Empty and null
-/// strings will always result in empty and null strings respectively no matter
-/// how many [times] they are [repeat]ed.
-///
-/// If [times] is negative, returns the reversed string repeated given number
-/// of [times].
-///
-/// DEPRECATED: use the `*` operator on [String].
-@deprecated
-String repeat(String s, int times) {
-  if (s == null || s == '') return s;
-  if (times < 0) {
-    return repeat(reverse(s), -times);
-  }
-  StringBuffer sink = new StringBuffer();
-  _repeat(sink, s, times);
-  return sink.toString();
-}
-
 /// Loops over [s] and returns traversed characters. Takes arbitrary [from] and
 /// [to] indices. Works as a substitute for [String.substring], except it never
 /// throws [RangeError]. Supports negative indices. Think of an index as a

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -88,25 +88,6 @@ main() {
     });
   });
 
-  group('repeat', () {
-    test('should repeat a non-empty string', () {
-      expect(repeat('ab', 3), 'ababab');
-    });
-    test(
-        'should repeat flipped non-empty string '
-        'on negative number of times', () {
-      expect(repeat('ab', -3), 'bababa');
-    });
-    test('should return null on null', () {
-      expect(repeat(null, 6), null);
-      expect(repeat(null, -6), null);
-    });
-    test('should return empty string on empty string', () {
-      expect(repeat('', 6), '');
-      expect(repeat('', -6), '');
-    });
-  });
-
   group('loop', () {
     // Forward direction test cases
     test('should work like normal substring', () {


### PR DESCRIPTION
repeat was deprecated in f60deadf89036a9e52a23e29a78f20218951f07a.
Callers should use the '*' operator on String instead.