### PR TITLE
Deprecate Strings.reverse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
      0.25.0.
    * BREAKING CHANGE: eliminated deprecated `repeat`. Deprecated in 0.25.0.
      Callers should use `String`'s `*` operator.
+   * Deprecated: `reverse` in the `strings` library. No replacement is
+     provided.
 
 #### 0.25.0 - 2017-03-28
    * BREAKING CHANGE: minimum SDK constraint increased to 1.21.0. This allows

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -25,6 +25,11 @@ bool isEmpty(String s) => s == null || s.isEmpty;
 bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 
 /// Returns a string with characters from the given [s] in reverse order.
+///
+/// DEPRECATED: without full support for unicode composed character sequences,
+/// sequences including zero-width joiners, etc. this function is unsafe to
+/// use. No replacement is provided.
+@deprecated
 String reverse(String s) {
   if (s == null || s == '') return s;
   StringBuffer sb = new StringBuffer();


### PR DESCRIPTION
Without full unicode support for composed character sequences,
sequences inclduing zero-width joiners, etc., this function is unsafe
for general use.

No replacement is provided since, aside from novelty applications, this
function has relatively few uses.