### PR TITLE
Deprecate createTimer, createTimerPeriodic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
      Callers should use `String`'s `*` operator.
    * Deprecated: `reverse` in the `strings` library. No replacement is
      provided.
+   * Deprecated: `createTimer`, `createTimerPeriodic` in the `async` library.
+     These were originally written to support FakeTimer, which is superseded
+     by FakeAsync.
 
 #### 0.25.0 - 2017-03-28
    * BREAKING CHANGE: minimum SDK constraint increased to 1.21.0. This allows

--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ predicates.
 `CountdownTimer` is a simple countdown timer that fires events in regular
 increments.
 
-`CreateTimer` and `CreateTimerPeriodic` are typedefs that are useful for
-passing Timer factories to classes and functions, increasing the testability of
-code that depends on Timer.
-
 `Metronome` is a self-correcting alternative to `Timer.periodic`. It provides
 a simple, tracking periodic stream of `DateTime` events with optional anchor
 time.

--- a/lib/async.dart
+++ b/lib/async.dart
@@ -31,16 +31,26 @@ part 'src/async/stream_buffer.dart';
 part 'src/async/stream_router.dart';
 
 /// The signature of a one-shot [Timer] factory.
+@deprecated
 typedef Timer CreateTimer(Duration duration, void callback());
 
 /// Creates a new one-shot [Timer] using `new Timer(duration, callback)`.
+///
+/// DEPRECATED: for basic timer creation, construct a new timer directly. For
+/// testing applications, use `FakeAsync`.
+@deprecated
 Timer createTimer(Duration duration, void callback()) =>
     new Timer(duration, callback);
 
 /// The signature of a periodic timer factory.
+@deprecated
 typedef Timer CreateTimerPeriodic(Duration duration, void callback(Timer));
 
 /// Creates a new periodic [Timer] using
 /// `new Timer.periodic(duration, callback)`.
+///
+/// DEPRECATED: for basic timer creation, construct a new timer directly. For
+/// testing applications, use `FakeAsync`.
+@deprecated
 Timer createTimerPeriodic(Duration duration, void callback(Timer t)) =>
     new Timer.periodic(duration, callback);


### PR DESCRIPTION
These were originally authored in d5a10fec to support FakeTimer, which
was deprecated in be8d3772 and removed in 36cf71b5. FakeTimer was
superseded by FakeAsync, which provides a more comprehensive solution to
the problem these were originally written to solve.