### PR TITLE
Fix bad tail state in LRU map on removal of last entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 0.27.0-dev
+
+   * Fix: when removing the last item, `LinkedLruHashMap` was put into a state
+     such that the next cache eviction could cause a null-pointer exception.
+     Issue [#385](https://github.com/google/quiver-dart/issues/385).
+
 #### 0.26.0 - 2017-11-01
    * BREAKING CHANGE: eliminated deprecated `flip`. Replaced by `reverse` in
      0.25.0.

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -197,7 +197,9 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   V remove(Object key) {
     final entry = _entries.remove(key);
     if (entry != null) {
-      if (entry == _head) {
+      if (entry == _head && entry == _tail) {
+        _head = _tail = null;
+      } else if (entry == _head) {
         _head = _head.next;
       } else if (entry == _tail) {
         _tail.previous.next = null;

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -173,6 +173,16 @@ void main() {
         expect(lruMap.remove('D'), isNull);
       });
 
+      test('can remove the last item (head and tail)', () {
+        // See: https://github.com/google/quiver-dart/issues/385
+        lruMap = new LruMap(maximumSize: 1)
+          ..addAll({'A': 'Alpha'})
+          ..remove('A');
+        lruMap['B'] = 'Beta';
+        lruMap['C'] = 'Charlie';
+        expect(lruMap.keys.toList(), ['C']);
+      });
+
       test('can remove the head', () {
         lruMap.remove('C');
         expect(lruMap.keys.toList(), ['B', 'A']);


### PR DESCRIPTION
On removal of the last entry from an LRU map, the entry is both _head
and _tail. The existing remove() implementation matched it against
_head, which was then updated to _head.next (null), but _tail was left
unmodified in a bad state.

Since _tail is not null, the next insertion into the newly-empty map
don't reset it. When the map size eventually exceeds the maximum size,
_removeLru() is called to evict _tail, resulting in a null-pointer
exception as _removeLru() attempts to get _tail.previous (null) and then
set .next on that.