### PR TITLE
Fix memory leak in LruCache

### DIFF
--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -217,6 +217,11 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
 
   /// Moves [entry] to the MRU position, shifting the linked list if necessary.
   void _promoteEntry(_LinkedEntry<K, V> entry) {
+    // If this entry is already in the MRU position we are done.
+    if (entry == _head) {
+      return;
+    }
+
     if (entry.previous != null) {
       // If already existed in the map, link previous to next.
       entry.previous.next = entry.next;

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -231,6 +231,10 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
         _tail = entry.previous;
       }
     }
+    // If this entry is not the end of the list then link the next entry to the previous entry.
+    if (entry.next != null) {
+      entry.next.previous = entry.previous;
+    }
 
     // Replace head with this element.
     if (_head != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ authors:
 - Sean Eagan <seaneagan1@gmail.com>
 - Victor Berchet <victor@suumit.com>
 - Wil Pirino <willyp@google.com>
+- Adam Lofts <adam.lofts@gmail.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -159,6 +159,15 @@ void main() {
       expect(lruMap.values.toList(), ['Charlie', 'Beta', 'Alpha']);
     });
 
+    test('Re-adding the key in the first position does not create a loop #357', () {
+      lruMap = new LruMap();
+      lruMap['A'] = 'Alpha';
+      lruMap['A'] = 'Alpha';
+
+      expect(lruMap.keys.toList(), ['A']);
+      expect(lruMap.values.toList(), ['Alpha']);
+    });
+
     group('`remove`', () {
       setUp(() {
         lruMap = new LruMap()

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -159,7 +159,8 @@ void main() {
       expect(lruMap.values.toList(), ['Charlie', 'Beta', 'Alpha']);
     });
 
-    test('Re-adding the key in the first position does not create a loop #357', () {
+    test('Re-adding the head entry is a no-op', () {
+      // See: https://github.com/google/quiver-dart/issues/357
       lruMap = new LruMap();
       lruMap['A'] = 'Alpha';
       lruMap['A'] = 'Alpha';
@@ -208,14 +209,15 @@ void main() {
       });
     });
 
-    test ('Test that the linked list is correctly mutated when promoting an element in the middle', () {
+    test(
+        'Test that the linked list is correctly mutated when promoting an element in the middle',
+        () {
       LruMap<String, int> lruMap = new LruMap(maximumSize: 3)
-        ..addAll({ 'C': 1, 'A': 1, 'B': 1 });
+        ..addAll({'C': 1, 'A': 1, 'B': 1});
       lruMap['A'] = 1;
       lruMap['C'];
       expect(lruMap.length, lruMap.keys.length);
     });
-
 
     group('`putIfAbsent`', () {
       setUp(() {

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -208,6 +208,15 @@ void main() {
       });
     });
 
+    test ('Test that the linked list is correctly mutated when promoting an element in the middle', () {
+      LruMap<String, int> lruMap = new LruMap(maximumSize: 3)
+        ..addAll({ 'C': 1, 'A': 1, 'B': 1 });
+      lruMap['A'] = 1;
+      lruMap['C'];
+      expect(lruMap.length, lruMap.keys.length);
+    });
+
+
     group('`putIfAbsent`', () {
       setUp(() {
         lruMap = new LruMap()


### PR DESCRIPTION
The LruCache can leak memory because the previous pointer in the linked list is not correctly updated. 