### PR TITLE
Use the expanded test reporter

### DIFF
--- a/tool/travis.sh
+++ b/tool/travis.sh
@@ -29,7 +29,7 @@ fi
 
 # Run the tests.
 echo "Running tests..."
-pub run test:test
+pub run test:test --reporter expanded
 
 # Gather and send coverage data.
 if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "stable" ]; then


### PR DESCRIPTION
This ensures we emit one line per test as opposed to overwriting with
each pass.