### PR TITLE
MapCache: Prevent concurrent loads of the same key (#255)

### DIFF
--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -17,8 +17,8 @@ part of quiver.cache;
 /// A [Cache] that's backed by a [Map].
 class MapCache<K, V> implements Cache<K, V> {
   final Map<K, V> _map;
-  // Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
-  final Map<K, FutureOr<V>> _outstanding = {};
+  /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
+  final _outstanding = <K, FutureOr<V>>{};
 
   /// Creates a new [MapCache], optionally using [map] as the backing [Map].
   MapCache({Map<K, V> map}) : _map = map != null ? map : new HashMap<K, V>();

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -17,6 +17,7 @@ part of quiver.cache;
 /// A [Cache] that's backed by a [Map].
 class MapCache<K, V> implements Cache<K, V> {
   final Map<K, V> _map;
+
   /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
   final _outstanding = <K, FutureOr<V>>{};
 

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -70,7 +70,8 @@ main() {
 
       Future<String> loader(String key) {
         count += 1;
-        return new Future.delayed(const Duration(milliseconds: 1), () => "test");
+        return new Future.delayed(
+            const Duration(milliseconds: 1), () => "test");
       }
 
       await Future.wait([

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -70,7 +70,7 @@ main() {
 
       Future<String> loader(String key) {
         count += 1;
-        return new Future.delayed(new Duration(milliseconds: 1), () => "test");
+        return new Future.delayed(const Duration(milliseconds: 1), () => "test");
       }
 
       await Future.wait([

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -64,5 +64,21 @@ main() {
         expect(value, 'foofoo');
       });
     });
+
+    test("should not make multiple requests for the same key", () async {
+      int count = 0;
+
+      Future<String> loader(String key) {
+        count += 1;
+        return new Future.delayed(new Duration(milliseconds: 1), () => "test");
+      }
+
+      await Future.wait([
+        cache.get("test", ifAbsent: loader),
+        cache.get("test", ifAbsent: loader),
+      ]);
+
+      expect(count, equals(1));
+    });
   });
 }


### PR DESCRIPTION
Keep the set of outstanding calls to ifAbsent so that we can return the existing
Future if asked for the same key.

Fix: #255