### PR TITLE
Update with Dart 2.0 core library unimplemented implementations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 #### 0.27.0-dev
 
+   * BREAKING CHANGE: all classes that implement `Iterable`, `List`, `Map`,
+     `Queue`, `Set`, or `Timer` now implement stubs of upcoming Dart 2.0
+     methods. Any class that reimplements these classes also needs new method
+     implementations. The classes with these breaking changes include:
+     `HashBiMap`, `DelegatingIterable`, `DelegatingList`,
+     `DelegatingMap`,`DelegatingQueue`, `DelegatingSet`, `LinkedLruHashMap`,
+     `TreeSet`, and `AvlTreeSet`.
    * Fix: Use FIFO ordering in `FakeAsync`. PR
      [#265](https://github.com/google/quiver-dart/pull/265)
 

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -70,11 +70,45 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   int get length => _map.length;
   Iterable<V> get values => _inverse.keys;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("addEntries");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("entries");
+  }
+
   BiMap<V, K> get inverse {
     if (_cached == null) {
       _cached = new HashBiMap._from(_inverse, _map);
     }
     return _cached;
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("map");
   }
 
   V putIfAbsent(K key, V ifAbsent()) {
@@ -87,6 +121,34 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   V remove(Object key) {
     _inverse.remove(_map[key]);
     return _map.remove(key);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError("removeWhere");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError("retype");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError("update");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError("updateAll");
   }
 
   void clear() {

--- a/lib/src/collection/delegates/iterable.dart
+++ b/lib/src/collection/delegates/iterable.dart
@@ -29,6 +29,13 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
 
   bool any(bool test(E element)) => delegate.any(test);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
   bool contains(Object element) => delegate.contains(element);
 
   E elementAt(int index) => delegate.elementAt(index);
@@ -44,6 +51,13 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
 
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       delegate.fold(initialValue, combine);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<E> followedBy(Iterable<E> other) {
+    throw new UnimplementedError("followedBy");
+  }
 
   void forEach(void f(E element)) => delegate.forEach(f);
 
@@ -66,9 +80,19 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
 
   E reduce(E combine(E value, E element)) => delegate.reduce(combine);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
+
   E get single => delegate.single;
 
-  E singleWhere(bool test(E element)) => delegate.singleWhere(test);
+  E singleWhere(bool test(E element), {E orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
+    return delegate.singleWhere(test);
+  }
 
   Iterable<E> skip(int n) => delegate.skip(n);
 
@@ -83,4 +107,11 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   Set<E> toSet() => delegate.toSet();
 
   Iterable<E> where(bool test(E element)) => delegate.where(test);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
 }

--- a/lib/src/collection/delegates/list.dart
+++ b/lib/src/collection/delegates/list.dart
@@ -34,28 +34,79 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
     delegate[index] = value;
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<E> operator +(List<E> other) {
+    throw new UnimplementedError("+");
+  }
+
   void add(E value) => delegate.add(value);
 
   void addAll(Iterable<E> iterable) => delegate.addAll(iterable);
 
   Map<int, E> asMap() => delegate.asMap();
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingList<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingList<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
+
   void clear() => delegate.clear();
 
   void fillRange(int start, int end, [E fillValue]) =>
       delegate.fillRange(start, end, fillValue);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set first(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = element;
+  }
+
   Iterable<E> getRange(int start, int end) => delegate.getRange(start, end);
 
   int indexOf(E element, [int start = 0]) => delegate.indexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(E element), [int start = 0]) {
+    throw new UnimplementedError("indexWhere");
+  }
 
   void insert(int index, E element) => delegate.insert(index, element);
 
   void insertAll(int index, Iterable<E> iterable) =>
       delegate.insertAll(index, iterable);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set last(E element) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = element;
+  }
+
   int lastIndexOf(E element, [int start]) =>
       delegate.lastIndexOf(element, start);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(E element), [int start]) {
+    throw new UnimplementedError("lastIndexWhere");
+  }
 
   void set length(int newLength) {
     delegate.length = newLength;

--- a/lib/src/collection/delegates/map.dart
+++ b/lib/src/collection/delegates/map.dart
@@ -35,11 +35,36 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
 
   void addAll(Map<K, V> other) => delegate.addAll(other);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("addEntries");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
   void clear() => delegate.clear();
 
   bool containsKey(Object key) => delegate.containsKey(key);
 
   bool containsValue(Object value) => delegate.containsValue(value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("entries");
+  }
 
   void forEach(void f(K key, V value)) => delegate.forEach(f);
 
@@ -51,9 +76,46 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
 
   int get length => delegate.length;
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("map");
+  }
+
   V putIfAbsent(K key, V ifAbsent()) => delegate.putIfAbsent(key, ifAbsent);
 
   V remove(Object key) => delegate.remove(key);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError("removeWhere");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError("retype");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError("update");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError("updateAll");
+  }
 
   Iterable<V> get values => delegate.values;
 }

--- a/lib/src/collection/delegates/queue.dart
+++ b/lib/src/collection/delegates/queue.dart
@@ -36,6 +36,13 @@ abstract class DelegatingQueue<E> extends DelegatingIterable<E>
 
   void addLast(E value) => delegate.addLast(value);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingQueue<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
   void clear() => delegate.clear();
 
   bool remove(Object object) => delegate.remove(object);
@@ -47,4 +54,11 @@ abstract class DelegatingQueue<E> extends DelegatingIterable<E>
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
   void retainWhere(bool test(E element)) => delegate.retainWhere(test);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingQueue<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
 }

--- a/lib/src/collection/delegates/set.dart
+++ b/lib/src/collection/delegates/set.dart
@@ -32,6 +32,20 @@ abstract class DelegatingSet<E> extends DelegatingIterable<E>
 
   void addAll(Iterable<E> elements) => delegate.addAll(elements);
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingSet<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  DelegatingSet<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
+
   void clear() => delegate.clear();
 
   bool containsAll(Iterable<Object> other) => delegate.containsAll(other);

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -80,6 +80,22 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   void addAll(Map<K, V> other) => other.forEach((k, v) => this[k] = v);
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("addEntries");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  LinkedLruHashMap<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
   void clear() {
     _entries.clear();
     _head = _tail = null;
@@ -90,6 +106,15 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
 
   @override
   bool containsValue(Object value) => values.contains(value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("entries");
+  }
 
   /// Applies [action] to each key-value pair of the map in order of MRU to
   /// LRU.
@@ -130,6 +155,15 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   /// The returned iterable does *not* have efficient `length` or `contains`.
   @override
   Iterable<V> get values => _iterable().map((e) => e.value);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("map");
+  }
 
   @override
   int get maximumSize => _maximumSize;
@@ -213,7 +247,35 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   }
 
   @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError("removeWhere");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  LinkedLruHashMap<K2, V2> retype<K2, V2>() {
+    throw new UnimplementedError("retype");
+  }
+
+  @override
   String toString() => Maps.mapToString(this);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError("update");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError("updateAll");
+  }
 
   /// Moves [entry] to the MRU position, shifting the linked list if necessary.
   void _promoteEntry(_LinkedEntry<K, V> entry) {

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -304,7 +304,7 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  _WrappedMap<K2, V2, C2> retype<K2, V2, C2 extends Iterable<V2>>() {
+  Map<K2, V2> retype<K2, V2>() {
     throw new UnimplementedError("retype");
   }
 
@@ -329,7 +329,7 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+  Map<K2, V2> map<K2, V2>(Object transform(K key, C value)) {
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
     throw new UnimplementedError("map");
@@ -338,21 +338,21 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  V update(K key, V update(V value), {V ifAbsent()}) {
+  V update(K key, C update(C value), {C ifAbsent()}) {
     throw new UnimplementedError("update");
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  void updateAll(V update(K key, V value)) {
+  void updateAll(C update(K key, C value)) {
     throw new UnimplementedError("updateAll");
   }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
   // ignore: override_on_non_overriding_method
-  void removeWhere(bool test(K key, V value)) {
+  void removeWhere(bool test(K key, C value)) {
     throw new UnimplementedError("removeWhere");
   }
 }

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -293,6 +293,68 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
   int get length => _multimap.length;
   C remove(Object key) => _multimap.removeAll(key);
   Iterable<C> get values => _multimap._groupedValues;
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> cast<K2, V2>() {
+    throw new UnimplementedError("cast");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  _WrappedMap<K2, V2, C2> retype<K2, V2, C2 extends Iterable<V2>>() {
+    throw new UnimplementedError("retype");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  Iterable<Null> get entries {
+    // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("entries");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void addEntries(Iterable<Object> entries) {
+    // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("addEntries");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // Change Object to MapEntry<K2, V2> when
+    // the MapEntry class has been added.
+    throw new UnimplementedError("map");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  V update(K key, V update(V value), {V ifAbsent()}) {
+    throw new UnimplementedError("update");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void updateAll(V update(K key, V value)) {
+    throw new UnimplementedError("updateAll");
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  void removeWhere(bool test(K key, V value)) {
+    throw new UnimplementedError("removeWhere");
+  }
 }
 
 /// Iterable wrapper that syncs to an underlying map.
@@ -323,6 +385,13 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
   bool any(bool test(V element)) {
     _syncDelegate();
     return _delegate.any(test);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> cast<T>() {
+    throw new UnimplementedError("cast");
   }
 
   bool contains(Object element) {
@@ -358,6 +427,13 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
   T fold<T>(T initialValue, T combine(T previousValue, V element)) {
     _syncDelegate();
     return _delegate.fold(initialValue, combine);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<V> followedBy(Iterable<V> other) {
+    throw new UnimplementedError("followedBy");
   }
 
   void forEach(void f(V element)) {
@@ -410,12 +486,20 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     return _delegate.reduce(combine);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
+
   V get single {
     _syncDelegate();
     return _delegate.single;
   }
 
-  V singleWhere(bool test(V element)) {
+  V singleWhere(bool test(V element), {V orElse()}) {
+    if (orElse != null) throw new UnimplementedError("singleWhere:orElse");
     _syncDelegate();
     return _delegate.singleWhere(test);
   }
@@ -459,6 +543,13 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     _syncDelegate();
     return _delegate.where(test);
   }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Iterable<T> whereType<T>() {
+    throw new UnimplementedError("whereType");
+  }
 }
 
 class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
@@ -471,6 +562,13 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
   void operator []=(int index, V value) {
     _syncDelegate();
     _delegate[index] = value;
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<V> operator +(List<V> other) {
+    throw new UnimplementedError("+");
   }
 
   void add(V value) {
@@ -492,6 +590,13 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return _delegate.asMap();
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
   void clear() {
     _syncDelegate();
     _delegate.clear();
@@ -503,6 +608,14 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     _delegate.fillRange(start, end, fillValue);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set first(V value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[0] = value;
+  }
+
   Iterable<V> getRange(int start, int end) {
     _syncDelegate();
     return _delegate.getRange(start, end);
@@ -511,6 +624,13 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
   int indexOf(V element, [int start = 0]) {
     _syncDelegate();
     return _delegate.indexOf(element, start);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int indexWhere(bool test(V element), [int start = 0]) {
+    throw new UnimplementedError("indexWhere");
   }
 
   void insert(int index, V element) {
@@ -527,9 +647,24 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (wasEmpty) _addToMap();
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_setter
+  void set last(V value) {
+    if (this.isEmpty) throw new RangeError.index(0, this);
+    this[this.length - 1] = value;
+  }
+
   int lastIndexOf(V element, [int start]) {
     _syncDelegate();
     return _delegate.lastIndexOf(element, start);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  int lastIndexWhere(bool test(V element), [int start]) {
+    throw new UnimplementedError("lastIndexWhere");
   }
 
   void set length(int newLength) {
@@ -584,6 +719,13 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  List<T> retype<T>() {
+    throw new UnimplementedError("retype");
+  }
+
   Iterable<V> get reversed {
     _syncDelegate();
     return _delegate.reversed;
@@ -632,6 +774,13 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
     var wasEmpty = _delegate.isEmpty;
     _delegate.addAll(elements);
     if (wasEmpty) _addToMap();
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>() {
+    throw new UnimplementedError("cast");
   }
 
   void clear() {
@@ -689,6 +838,13 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
     _syncDelegate();
     _delegate.retainWhere(test);
     if (_delegate.isEmpty) _map.remove(_key);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError("retype");
   }
 
   Set<V> union(Set<V> other) {

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -376,6 +376,13 @@ class AvlTreeSet<V> extends TreeSet<V> {
     return modified;
   }
 
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  AvlTreeSet<T> cast<T>() {
+    throw new UnimplementedError("cast");
+  }
+
   void clear() {
     _length = 0;
     _root = null;
@@ -597,6 +604,13 @@ class AvlTreeSet<V> extends TreeSet<V> {
     }
     clear();
     addAll(chosen);
+  }
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>() {
+    throw new UnimplementedError("retype");
   }
 
   /// See [Set.removeWhere]

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -51,6 +51,14 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   /// if missing.  See [TreeSearch].
   V nearest(V object, {TreeSearch nearestOption: TreeSearch.NEAREST});
 
+  @override
+  // ignore: override_on_non_overriding_method
+  Set<T> cast<T>();
+
+  @override
+  // ignore: override_on_non_overriding_method
+  Set<T> retype<T>();
+
   // TODO: toString or not toString, that is the question.
 }
 

--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -285,4 +285,11 @@ class _FakeTimer implements Timer {
   bool get isActive => _time._hasTimer(this);
 
   cancel() => _time._cancelTimer(this);
+
+  @override
+  // TODO: Dart 2.0 requires this method to be implemented.
+  // ignore: override_on_non_overriding_getter
+  int get tick {
+    throw new UnimplementedError("tick");
+  }
 }


### PR DESCRIPTION
Updated the collection classes and the timer class with new Dart 2.0 default implementations, from [this gist](https://gist.github.com/lrhn/b99fe5f73a10b3b1a91579853056d08b).

Once the base collection classes have docs and implementations, we can flesh these out. This PR just allows a user to depend on quiver while using Dart 2.0 once the collection classes have new methods.