### PR TITLE
Add breaking changes to 0.26.0 entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,10 @@
      0.25.0.
    * BREAKING CHANGE: eliminated deprecated `repeat`. Deprecated in 0.25.0.
      Callers should use `String`'s `*` operator.
+   * BREAKING CHANGE: `collect`, `concat`, `doWhileAsync`, `enumerate`,
+     `extent`, `forEachAsync`, `max`, `merge`, `min`, `reduceAsync`, and `zip`
+     are now type parameterized. Depending on the inferred value of each type
+     parameter, the return type of each function may change in existing code.
    * Deprecated: `reverse` in the `strings` library. No replacement is
      provided.
    * Deprecated: `createTimer`, `createTimerPeriodic` in the `async` library.


### PR DESCRIPTION
Fixes #401, #402, #403, and #405.

By documenting the changes in #367, #374, #375, and #377.