### PR TITLE
Remove usage of Maps.mapToString()

### DIFF
--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -261,7 +261,32 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   }
 
   @override
-  String toString() => Maps.mapToString(this);
+  String toString() {
+    // Detect toString() cycles.
+    if (_isToStringVisiting(this)) {
+      return '{...}';
+    }
+
+    var result = new StringBuffer();
+    try {
+      _toStringVisiting.add(this);
+      result.write('{');
+      bool first = true;
+      forEach((k, v) {
+        if (!first) {
+          result.write(', ');
+        }
+        first = false;
+        result.write('$k: $v');
+      });
+      result.write('}');
+    } finally {
+      assert(identical(_toStringVisiting.last, this));
+      _toStringVisiting.removeLast();
+    }
+
+    return result.toString();
+  }
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.
@@ -338,3 +363,9 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
     _tail.next = null;
   }
 }
+
+/// A collection used to identify cyclic maps during toString() calls.
+final List _toStringVisiting = [];
+
+/// Check if we are currently visiting `o` in a toString() call.
+bool _isToStringVisiting(o) => _toStringVisiting.any((e) => identical(o, e));

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -261,6 +261,8 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   }
 
   @override
+  // TODO: Use the `MapBase.mapToString()` static method when the minimum SDK
+  // version of this package has been bumped to 2.0.0 or greater.
   String toString() {
     // Detect toString() cycles.
     if (_isToStringVisiting(this)) {

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -243,7 +243,7 @@ void main() {
     });
   });
 
-group("LruMap builds an informative string representation", () {
+  group("LruMap builds an informative string representation", () {
     LruMap<String, dynamic> lruMap;
 
     setUp(() {
@@ -255,14 +255,13 @@ group("LruMap builds an informative string representation", () {
     });
 
     test("for a map with one value", () {
-        lruMap.addAll({'A': 'Alpha'});
+      lruMap.addAll({'A': 'Alpha'});
       expect(lruMap.toString(), equals('{A: Alpha}'));
     });
 
     test("for a map with multiple values", () {
-        lruMap.addAll({'A': 'Alpha', 'B': 'Beta', 'C': 'Charlie'});
-      expect(
-          lruMap.toString(), equals('{C: Charlie, B: Beta, A: Alpha}'));
+      lruMap.addAll({'A': 'Alpha', 'B': 'Beta', 'C': 'Charlie'});
+      expect(lruMap.toString(), equals('{C: Charlie, B: Beta, A: Alpha}'));
     });
 
     test("for a map with a loop", () {

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -242,4 +242,32 @@ void main() {
       });
     });
   });
+
+group("LruMap builds an informative string representation", () {
+    LruMap<String, dynamic> lruMap;
+
+    setUp(() {
+      lruMap = new LruMap();
+    });
+
+    test("for an empty map", () {
+      expect(lruMap.toString(), equals('{}'));
+    });
+
+    test("for a map with one value", () {
+        lruMap.addAll({'A': 'Alpha'});
+      expect(lruMap.toString(), equals('{A: Alpha}'));
+    });
+
+    test("for a map with multiple values", () {
+        lruMap.addAll({'A': 'Alpha', 'B': 'Beta', 'C': 'Charlie'});
+      expect(
+          lruMap.toString(), equals('{C: Charlie, B: Beta, A: Alpha}'));
+    });
+
+    test("for a map with a loop", () {
+      lruMap.addAll({"A": "Alpha", "B": lruMap});
+      expect(lruMap.toString(), equals('{B: {...}, A: Alpha}'));
+    });
+  });
 }


### PR DESCRIPTION
`Maps.mapToString()` is going to be removed by Dart 2.0. It will be moved to `MapBase.mapToString()`. To avoid bumping the minimum SDK version, we can just copy the implementation (~30 lines) to this package.

(This is the same fix that was applied to collection, https://github.com/dart-lang/collection/pull/71.)