### PR TITLE
Add Optional.transformNullable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 2.0.1 - 2018-10-22
+
+   * New: Optional now includes `transformNullable` to pass maybe present
+     values through a transformer with a nullable return value.
+
 #### 2.0.0+1 - 2017-07-18
 
    * Updated Dart SDK constraint to >=2.0.0-dev.61 < 3.0.0.

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -90,6 +90,17 @@ class Optional<T> extends IterableBase<T> {
         : new Optional.of(transformer(_value));
   }
 
+  /// Transforms the Optional value.
+  ///
+  /// If the Optional is [absent()], returns [absent()] without applying the transformer.
+  ///
+  /// Returns [absent()] if the transformer returns [null].
+  Optional<S> transformNullable<S>(S transformer(T value)) {
+    return _value == null
+        ? new Optional.absent()
+        : new Optional.fromNullable(transformer(_value));
+  }
+
   @override
   Iterator<T> get iterator =>
       isPresent ? <T>[_value].iterator : new Iterable<T>.empty().iterator;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 2.0.0+1
+version: 2.0.1
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ authors:
 - Wil Pirino <willyp@google.com>
 - Adam Lofts <adam.lofts@gmail.com>
 - Alec Henninger <alechenninger@gmail.com>
+- Mark Fielbig <mfielbig@gmail.com>
 description: A set of utility libraries for Dart
 homepage: https://github.com/google/quiver-dart
 environment:

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -77,6 +77,31 @@ main() {
           isFalse);
     });
 
+    test('transform should throw ArgumentError if transformed value is null',
+        () {
+      expect(() => new Optional<int>.fromNullable(7).transform((_) => null),
+          throwsArgumentError);
+    });
+
+    test('transformNullable should return transformed value or absent', () {
+      expect(new Optional<int>.fromNullable(7).transformNullable((a) => a + 1),
+          equals(new Optional<int>.of(8)));
+      expect(
+          new Optional<int>.fromNullable(null)
+              .transformNullable((a) => a + 1)
+              .isPresent,
+          isFalse);
+    });
+
+    test('transformNullable should return absent if transformed value is null',
+        () {
+      expect(
+          new Optional<int>.fromNullable(7)
+              .transformNullable((_) => null)
+              .isPresent,
+          isFalse);
+    });
+
     test('hashCode should allow optionals to be in hash sets', () {
       expect(
           new Set.from([


### PR DESCRIPTION
This lets callers chain maybe-present values through transformers with a nullable return value.

The existing Optional.transform throws an `ArgumentException` if the transformer returns `null`. Would be great to have an API that returns `absent()` if the transformer returns `null`.

I added this as a new function for backwards compatibility sake, but I'd argue that Optional.transform should have this behavior -- depends on what your policy is for breaking changes.

Inspiration taken from Java 8's [`Optional#map`](https://docs.oracle.com/javase/8/docs/api/java/util/Optional.html#map-java.util.function.Function-):

>If a value is present, apply the provided mapping function to it, and if the result is non-null, return an Optional describing the result. Otherwise return an empty Optional.