### PR TITLE
Update CHANGELOG/pubspec to include 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
    * New: DelegatingList now includes real implementations of `operator +`,
      `indexWhere`, and `lastIndexWhere`.
 
+#### 0.28.0+1 - 2018-03-22
+
+   * Remove use of `Maps.mapToString` in `LruMap`.
+   * Add @visibleForTesting annotation in `AvlTreeSet`.
+
 #### 0.28.0 - 2018-01-19
 
    * BREAKING CHANGE: The signature of `MultiMap`'s `update` stub has changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add Quiver to your project's pubspec.yaml file and run `pub get`.
 We recommend the following version constraint:
 
     dependencies:
-      quiver: '>=0.28.0 <0.29.0'
+      quiver: '>=0.28.1 <0.29.0'
 
 # Main Libraries
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 0.28.0
+version: 0.28.1
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
Merges 27efc6c83c5a03180067d66a0068991876719653 from branch dart_1.