### PR TITLE
Ensure that LruMap linkage is preserved

### DIFF
--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -235,11 +235,13 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
         _head = _tail = null;
       } else if (entry == _head) {
         _head = _head.next;
+        _head?.previous = null;
       } else if (entry == _tail) {
-        _tail.previous.next = null;
         _tail = _tail.previous;
+        _tail?.next = null;
       } else {
         entry.previous.next = entry.next;
+        entry.next.previous = entry.previous;
       }
       return entry.value;
     }

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -207,6 +207,15 @@ void main() {
         lruMap.remove('B');
         expect(lruMap.keys.toList(), ['C', 'A']);
       });
+
+      test('linkage correctly preserved on remove', () {
+        lruMap.remove('B');
+        lruMap['A'];
+
+        final keys = <String>[];
+        lruMap.forEach((String k, String v) => keys.add(k));
+        expect(keys, ['A', 'C']);
+      });
     });
 
     test(


### PR DESCRIPTION
Fixes two scenarios:
1. When a non-{head,tail} entry is removed, ensures that the next
   entry's 'previous' link is correctly linked to the removed entry's
   previous entry.
2. When the head entry is removed, ensure's that the new head's
   'previous' link is nulled.