### PR TITLE
Add .dart_tool to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 packages
 pubspec.lock
 build/
+.dart_tool/
 .pub
 .packages
 


### PR DESCRIPTION
Pub and other dart tools now write cache files to the .dart_tool
subdirectory.