### PR TITLE
Update changelog with Dart 2 breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 #### Master
 
+   * BREAKING CHANGE: This version requires Dart SDK 2.0.0-dev.30 or later.
+     Bugfixes will be backported to the 0.28.x series for Dart 1 users.
    * New: BiMap now includes a real implementation of `addEntries`, `get
      entries`, `map`, `removeWhere`, `update`, and `updateAll`.
    * New: DelegatingIterable now includes a real implementation of


### PR DESCRIPTION
Version 0.29.0 and higher will be Dart 2 only. Bugfixes will be
backported to the 0.28.x series on the dart_1 branch.