### PR TITLE
Update changelog for version 0.28.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,13 @@
    * New: The iterable keys of `ListMultimap` and `SetMultimap` now include a
      real implementation of `followedBy`, and accept the `orElse` parameter on
      `singleWhere`.
+
+#### 0.28.2 - 2018-03-24
+
    * Fix: Eliminate a bug where `LruMap` linkage is incorrectly preserved when
      items are removed.
 
-#### 0.28.0+1 - 2018-03-22
+#### 0.28.1 - 2018-03-22
 
    * Remove use of `Maps.mapToString` in `LruMap`.
    * Add `@visibleForTesting` annotation in `AvlTreeSet`.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add Quiver to your project's pubspec.yaml file and run `pub get`.
 We recommend the following version constraint:
 
     dependencies:
-      quiver: '>=0.28.1 <0.29.0'
+      quiver: '>=0.28.2 <0.29.0'
 
 # Main Libraries
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 0.28.1
+version: 0.28.2
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
The fix for LruMap committed in 84968bd was released in 0.28.2 on the
`dart_1` branch.