### PR TITLE
Eliminate unused import

### DIFF
--- a/lib/testing/async.dart
+++ b/lib/testing/async.dart
@@ -18,7 +18,6 @@ library quiver.testing.async;
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:quiver/iterables.dart';
 import 'package:quiver/time.dart';
 
 part 'src/async/fake_async.dart';


### PR DESCRIPTION
quiver/iterables.dart is no longer used in testing/async.dart.