### PR TITLE
Update 0.26.0 changelog with breaking change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,7 @@
    * BREAKING CHANGE: `Optional`'s `==` operator now takes into account `T`,
      the type of the value. This changes, e.g. `Optional<int>.absent()` to no
      longer be equal to `Optional<String>.absent()`.
+   * BREAKING CHANGE: stronger generics added in `Cache` and `MapCache`.
    * Deprecated: `reverse` in the `strings` library. No replacement is
      provided.
    * Deprecated: `createTimer`, `createTimerPeriodic` in the `async` library.


### PR DESCRIPTION
This documents a breaking change that occurred in 5a9d955 which added
stronger types on `Cache` and `MapCache`.