### PR TITLE
Pass coveralls repo token explicitly

### DIFF
--- a/tool/travis/coverage.sh
+++ b/tool/travis/coverage.sh
@@ -34,5 +34,5 @@ if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
     --packages=.packages \
     --report-on=lib
 
-  coveralls-lcov var/lcov.info
+  coveralls-lcov --repo-token="$REPO_TOKEN" var/lcov.info
 fi


### PR DESCRIPTION
Pass the token to coveralls-lcov explicitly instead of relying on the
REPO_TOKEN environment variable. It appears the environment variable
these days is COVERALLS_REPO_TOKEN.