### PR TITLE
Apply version constraint for package coverage

### DIFF
--- a/tool/travis/coverage.sh
+++ b/tool/travis/coverage.sh
@@ -8,7 +8,9 @@
 set -e
 
 # Gather and send coverage data.
-if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
+if [ "$COVERALLS_REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
+  pub global activate coverage ">=0.10.0"
+
   OBS_PORT=9292
   echo "Collecting coverage on port $OBS_PORT..."
 
@@ -20,7 +22,6 @@ if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
     test/all_tests.dart &
 
   # Run the coverage collector to generate the JSON coverage report.
-  pub global activate coverage
   echo "Collecting coverage..."
   pub global run coverage:collect_coverage \
     --port=$OBS_PORT \
@@ -37,5 +38,5 @@ if [ "$REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
     --report-on=lib
 
   echo "Uploading to Coveralls..."
-  coveralls-lcov --repo-token="$REPO_TOKEN" var/lcov.info
+  coveralls-lcov --repo-token="$COVERALLS_REPO_TOKEN" var/lcov.info
 fi


### PR DESCRIPTION
Require package:coverage version >= 0.10.0 for Dart 2 compatibility.

Also includes:
* Use COVERALLS_REPO_TOKEN environment variable for coveralls token.
* Minor re-ordering of package:coverage install for readability.