### PR TITLE
Run dartdevc-compiled web tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,20 @@ jobs:
   include:
     # presubmit: Check things that should fail fast(er).
     - stage: presubmit
-      env: [ SHARD=dartfmt ]
+      env: SHARD=dartfmt
       script: ./tool/travis/task.sh dartfmt
 
     - stage: presubmit
-      env: [ SHARD=dartanalyzer ]
+      env: SHARD=dartanalyzer
       script: ./tool/travis/task.sh dartanalyzer
 
-    # testing: Run test suites (Dart VM, DartDevC, Dart2JS).
+    # testing: Run test suites (Dart VM, Dart2JS).
     - stage: testing
-      env: [ SHARD=vm_test ]
+      env: SHARD=vm_test
       script: ./tool/travis/task.sh vm_test
 
     - stage: testing
-      env: [ SHARD=dart2js_test ]
+      env: SHARD=dart2js_test
       addons:
         chrome: stable
       before_install:
@@ -41,9 +41,22 @@ jobs:
         - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"
       script: ./tool/travis/task.sh dart2js_test
 
+    - stage: testing
+      env: SHARD=dartdevc_test
+      addons:
+        chrome: stable
+      before_install:
+        - export DISPLAY=:99.0
+        - sh -e /etc/init.d/xvfb start
+        - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"
+      script: ./tool/travis/task.sh dartdevc_test
+      cache:
+        directories:
+          - .dart_tool
+
     # coverage.
     - stage: coverage
-      env: [ SHARD=coveralls ]
+      env: SHARD=coveralls
       install:
         - gem install coveralls-lcov
       script: ./tool/travis/coverage.sh

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,3 +24,10 @@ dependencies:
 dev_dependencies:
   path: '>=1.0.0 <2.0.0'
   test: '>=0.12.20 <=0.13.0'
+#DDC_TEST:  build_runner: ^0.8.0
+#DDC_TEST:  build_test: ^0.10.0
+#DDC_TEST:  build_web_compilers: ^0.3.1
+
+# The above dependencies are used for running the dartdevc_test task on Travis.
+# Since build_runner indirectly depends on quiver, we patch these in at test
+# time to avoid creating a circular dependency.

--- a/tool/travis/ddc_test.sh
+++ b/tool/travis/ddc_test.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2018 Google Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+echo "Creating DDC test dir..."
+TEST_DIR="$(mktemp -d)"
+
+echo "Copying package sources..."
+cp -r . "$TEST_DIR"
+
+pushd "$TEST_DIR" > /dev/null 2>&1
+
+# Hack additional dev dependencies into pubspec.yaml
+#
+# We can't check these in because build_runner indirectly depends on quiver,
+# which introduces a circular dependency and makes pub upset.
+echo "Patching pubspec..."
+sed -i -e 's/#DDC_TEST://' pubspec.yaml
+
+echo "Running pub get..."
+pub get
+
+echo "Running tests..."
+pub run build_runner test -- "$@" || EXIT_CODE=$?
+
+popd > /dev/null 2>&1
+
+echo "Cleaning up..."
+rm -rf "$TEST_DIR"
+
+exit $EXIT_CODE

--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -41,8 +41,12 @@ while (( "$#" )); do
     ;;
   dart2js_test) echo
     echo -e '\033[1mTASK: dart2js_test\033[22m'
-    echo -e 'pub run test -p chrome -x "fails-on-dart2js"'
-    pub run test -p chrome -x "fails-on-dart2js" -r expanded || EXIT_CODE=$?
+    echo -e 'pub run test -p chrome -x fails-on-dart2js'
+    pub run test -p chrome -x fails-on-dart2js -r expanded || EXIT_CODE=$?
+    ;;
+  dartdevc_test) echo
+    echo -e '\033[1mTASK: dartdevc_test\033[22m'
+    ./tool/travis/ddc_test.sh -p chrome -x fails-on-dartdevc -r expanded || EXIT_CODE=$?
     ;;
   *) echo -e "\033[31mUnknown task: '${TASK}'. Error!\033[0m"
     EXIT_CODE=1


### PR DESCRIPTION
Re-enables DDC web tests on Travis.

The build_runner package makes DDC testing quick and easy, but
indirectly depends on quiver, which introduces a circular dependency. To
avoid this, we patch the pubspec for the test run only.

This change also sets `env` to a single variable rather that a list of one var.