### PR TITLE
Immediately return null for empty inputs in min, max, extent

### DIFF
--- a/lib/src/iterables/min_max.dart
+++ b/lib/src/iterables/min_max.dart
@@ -21,6 +21,7 @@ part of quiver.iterables;
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
 T max<T>(Iterable<T> i, [Comparator<T> compare]) {
+  if (i.isEmpty) return null;
   final Comparator<T> _compare = compare ?? Comparable.compare;
   return i.isEmpty ? null : i.reduce((a, b) => _compare(a, b) > 0 ? a : b);
 }
@@ -32,6 +33,7 @@ T max<T>(Iterable<T> i, [Comparator<T> compare]) {
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
 T min<T>(Iterable<T> i, [Comparator<T> compare]) {
+  if (i.isEmpty) return null;
   final Comparator<T> _compare = compare ?? Comparable.compare;
   return i.isEmpty ? null : i.reduce((a, b) => _compare(a, b) < 0 ? a : b);
 }
@@ -48,6 +50,7 @@ T min<T>(Iterable<T> i, [Comparator<T> compare]) {
 /// If [i] is empty, an [Extent] is returned with [:null:] values for [:min:]
 /// and [:max:], since there are no valid values for them.
 Extent<T> extent<T>(Iterable<T> i, [Comparator<T> compare]) {
+  if (i.isEmpty) return new Extent(null, null);
   final Comparator<T> _compare = compare ?? Comparable.compare;
   var iterator = i.iterator;
   var hasNext = iterator.moveNext();


### PR DESCRIPTION
This helps with fractionally quicker bailout, and prevents the following error when compiled with DDC and passed an empty list:
```
Type '(Comparable, Comparable) => int' is not a subtype of type '(dynamic, dynamic) => int' in strong mode
```