### PR TITLE
Eliminate DDC error in merge tests

### DIFF
--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -24,11 +24,11 @@ part of quiver.iterables;
 ///
 /// If any of the [iterables] contain null elements, an exception will be
 /// thrown.
-Iterable<T> merge<T>(Iterable<Iterable<T>> iterables,
-        [Comparator<T> compare]) =>
-    iterables.isEmpty
-        ? const <Null>[]
-        : new _Merge<T>(iterables, compare ?? Comparable.compare);
+Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T> compare]) {
+  if (iterables.isEmpty) return const <Null>[];
+  if (iterables.every((i) => i.isEmpty)) return const <Null>[];
+  return new _Merge<T>(iterables, compare ?? Comparable.compare);
+}
 
 class _Merge<T> extends IterableBase<T> {
   final Iterable<Iterable<T>> _iterables;

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -54,8 +54,8 @@ main() {
 
     test("should merge empty iterables with non-empty ones", () {
       var a = ['a', 'b', 'c'];
-      expect(merge([a, []]), ['a', 'b', 'c']);
-      expect(merge([[], a]), ['a', 'b', 'c']);
+      expect(merge([a, <String>[]]), ['a', 'b', 'c']);
+      expect(merge([<String>[], a]), ['a', 'b', 'c']);
     });
 
     test("should throw on null elements", () {


### PR DESCRIPTION
Bails out a little bit faster when there are no non-empty input
iterables. Eliminates the following DDC error in tests with an empty
input iterable:
```
Type '(Comparable, Comparable) => int' is not a subtype of type '(dynamic, dynamic) => int' in strong mode
```