### PR TITLE
Update master to reflect release of 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,6 @@
 
    * BREAKING CHANGE: This version requires Dart SDK 2.0.0-dev.30 or later.
      Bugfixes will be backported to the 0.28.x series for Dart 1 users.
-   * BREAKING CHANGE: Deleted `createTimer` and `createTimerPeriodic`, which
-     were deprecated in 0.26.0.
-   * BREAKING CHANGE: Deleted `reverse`, which was deprecated in 0.25.0.
-   * BREAKING CHANGE: Deleted `FutureGroup`, which was deprecated in 0.25.0.
-   * BREAKING CHANGE: `InfiniteIterable.singleWhere` now throws
-     `UnsupportedError`.
    * New: BiMap now includes a real implementation of `addEntries`, `get
      entries`, `map`, `removeWhere`, `update`, and `updateAll`.
    * New: DelegatingIterable now includes a real implementation of
@@ -26,6 +20,15 @@
    * New: The iterable keys of `ListMultimap` and `SetMultimap` now include a
      real implementation of `followedBy`, and accept the `orElse` parameter on
      `singleWhere`.
+
+#### 0.29.0 - 2018-03-28
+
+   * BREAKING CHANGE: Deleted `createTimer` and `createTimerPeriodic`, which
+     were deprecated in 0.26.0.
+   * BREAKING CHANGE: Deleted `reverse`, which was deprecated in 0.25.0.
+   * BREAKING CHANGE: Deleted `FutureGroup`, which was deprecated in 0.25.0.
+   * BREAKING CHANGE: `InfiniteIterable.singleWhere` now throws
+     `UnsupportedError`.
 
 #### 0.28.2 - 2018-03-24
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Add Quiver to your project's pubspec.yaml file and run `pub get`.
 We recommend the following version constraint:
 
     dependencies:
-      quiver: '>=0.28.2 <0.29.0'
+      quiver: '>=0.29.0 <0.30.0'
 
 # Main Libraries
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 0.28.2
+version: 0.29.0+1
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
Version 0.29.0 was released from the dart_1 branch. This backports the
CHANGELOG, README, and pubspec changes from the dart_1 branch to master.

dart_1 is a maintenance branch that remains compatible with Dart SDK
versions back to 1.21.0. The master branch requires Dart 2.