### PR TITLE
Fix some docs

### DIFF
--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -31,12 +31,14 @@ part of quiver.async;
 ///
 /// Could print the following stream of events, anchored by epoch, till the
 /// stream is canceled:
+///
 ///     2014-05-04 14:06:00.001
 ///     2014-05-04 14:07:00.000
 ///     2014-05-04 14:08:00.003
 ///     ...
 ///
 /// Example anchored in the future (now = 2014-05-05 20:06:00.123)
+///
 ///     new IsochronousStream.periodic(aMillisecond * 100,
 ///         anchorMs: DateTime.parse("2014-05-05 21:07:00"))
 ///         .listen(print);

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -31,9 +31,10 @@ class UnderflowError extends Error {
 }
 
 /// Allow orderly reading of elements from a datastream, such as Socket, which
-/// might not receive List<int> bytes regular chunks.
+/// might not receive `List<int>` bytes regular chunks.
 ///
 /// Example usage:
+///
 ///     StreamBuffer<int> buffer = new StreamBuffer();
 ///     Socket.connect('127.0.0.1', 5555).then((sock) => sock.pipe(buffer));
 ///     buffer.read(100).then((bytes) {

--- a/lib/src/async/stream_router.dart
+++ b/lib/src/async/stream_router.dart
@@ -23,6 +23,7 @@ part of quiver.async;
 /// matched by a call to [route] are sent to the [defaultStream].
 ///
 /// Example:
+///
 ///    import 'dart:html';
 ///    import 'package:quiver/async.dart';
 ///

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -69,7 +69,7 @@ abstract class Multimap<K, V> {
   /// Removes all data from the multimap.
   void clear();
 
-  /// Applies [f] to each {key, Iterable<value>} pair of the multimap.
+  /// Applies [f] to each {key, `Iterable<value>`} pair of the multimap.
   ///
   /// It is an error to add or remove keys from the map during iteration.
   void forEachKey(void f(K key, Iterable<V> value));


### PR DESCRIPTION
New (as in like... months ago?) Markdown requires a space between paragraph text and indented code. Also things like `List<int>` must be in code, or the `<int>` gets swallowed as HTML. 🙁 