### PR TITLE
Exclude mirrors_test from DDC build

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,0 +1,6 @@
+targets:
+  $default:
+    builders:
+      build_web_compilers|entrypoint:
+        generate_for:
+          exclude: ["test/all_tests.*", "test/mirrors_test.*"]


### PR DESCRIPTION
Note the .* match, this is required to match not just the input sources,
but also the generated files (e.g., foo.browser_test.dart).