### PR TITLE
Failed request should not be cached ( #461)

### DIFF
--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -41,9 +41,15 @@ class MapCache<K, V> implements Cache<K, V> {
     if (ifAbsent != null) {
       var futureOr = ifAbsent(key);
       _outstanding[key] = futureOr;
-      var v = await futureOr;
+      V v;
+      try {
+        v = await futureOr;
+      } finally {
+        // Always remove key from [_outstanding] to prevent returning the
+        // failed result again.
+        _outstanding.remove(key);
+      }
       _map[key] = v;
-      _outstanding.remove(key);
       return v;
     }
     return null;

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -81,5 +81,21 @@ main() {
 
       expect(count, equals(1));
     });
+
+    test("should not cache a failed request", () async {
+      int count = 0;
+
+      Future<String> loader(String key) {
+        count += 1;
+        return new Future.error("Request failed");
+      }
+
+      await Future.wait([
+        expectThrows(() => cache.get("test", ifAbsent: loader)),
+        expectThrows(() => cache.get("test", ifAbsent: loader)),
+      ]);
+
+      expect(count, equals(2));
+    });
   });
 }


### PR DESCRIPTION
If a [futureOr] fails, [_outstanding] caches it. Therefore, the next time, it returns the cached failed request from [_outstanding].

With this fix, a failed [futureOr] is never cached.