### PR TITLE
Fix MISSING_RETURN error in concat.dart

### DIFF
--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -71,7 +71,7 @@ class _ConcatStream<T> extends Stream<T> {
     }, onResume: () {
       if (currentSubscription != null) currentSubscription.resume();
     }, onCancel: () {
-      if (currentSubscription != null) return currentSubscription.cancel();
+      if (currentSubscription != null) currentSubscription.cancel();
     });
 
     nextStream();

--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -71,8 +71,10 @@ class _ConcatStream<T> extends Stream<T> {
     }, onResume: () {
       if (currentSubscription != null) currentSubscription.resume();
     }, onCancel: () {
-      if (currentSubscription != null) return currentSubscription.cancel();
-      else return null;
+      if (currentSubscription != null)
+        return currentSubscription.cancel();
+      else
+        return null;
     });
 
     nextStream();

--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -71,7 +71,8 @@ class _ConcatStream<T> extends Stream<T> {
     }, onResume: () {
       if (currentSubscription != null) currentSubscription.resume();
     }, onCancel: () {
-      if (currentSubscription != null) currentSubscription.cancel();
+      if (currentSubscription != null) return currentSubscription.cancel();
+      else return null;
     });
 
     nextStream();


### PR DESCRIPTION
Having the return statement led... inference or something to think that this function could have return values, and then it didn't _always_ return.