### PR TITLE
Add info message when not running coverage

### DIFF
--- a/tool/travis/coverage.sh
+++ b/tool/travis/coverage.sh
@@ -50,4 +50,6 @@ if [ "$COVERALLS_REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
 
   echo "Uploading to Coveralls..."
   coveralls-lcov --repo-token="$COVERALLS_REPO_TOKEN" var/lcov.info
+else
+  echo "Not running coverage."
 fi


### PR DESCRIPTION
We require both a coverage token Dart dev SDK build to run coverage.
This just adds a short info message to make it clear coverage isn't run
in other cases.