### PR TITLE
Add no-response bot config

### DIFF
--- a/.github/no-repsonse.yml
+++ b/.github/no-repsonse.yml
@@ -1,0 +1,16 @@
+# Configuration for probot-no-response - https://github.com/probot/no-response
+
+# Number of days of inactivity before an Issue is closed for lack of response
+daysUntilClose: 21
+
+# Label requiring a response
+responseRequiredLabel: "awaiting response"
+
+# Comment to post when closing an Issue for lack of response. Set to `false` to disable
+closeComment: >-
+  Without additional information, we are unfortunately not sure how to resolve
+  this issue. We are therefore reluctantly going to close this issue for now.
+  Please don't hesitate to comment on the issue if you have any more
+  information for us; we will reopen it right away!
+  
+  Thanks for your contribution.


### PR DESCRIPTION
Automatically close issues marked 'awaiting response' if no response has
been posted within 21 days.