### PR TITLE
Disable VM service port auth codes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ sudo: required
 # Build stages: https://docs.travis-ci.com/user/build-stages/.
 stages:
   - presubmit
-  - build
   - testing
+  - coverage
 
 # 1. Run dartfmt, dartanalyzer.
 # 2. Then run tests compiled via dartdevc and dart2js.

--- a/tool/travis/coverage.sh
+++ b/tool/travis/coverage.sh
@@ -28,6 +28,7 @@ if [ "$COVERALLS_REPO_TOKEN" ] && [ "$TRAVIS_DART_VERSION" = "dev" ]; then
   # Start tests in one VM.
   echo "Starting tests..."
   dart \
+    --disable-service-auth-codes \
     --enable-vm-service=$OBS_PORT \
     --pause-isolates-on-exit \
     test/all_tests.dart &


### PR DESCRIPTION
Coverage is currently broken due to recent VMs shipping with service port security auth codes enabled by default. This disables auth codes until the coverage package is updated to handle them.

Also fixes an extraneous `build` stage in travis.yml.