### PR TITLE
Narrow generate_for glob in build.yaml

### DIFF
--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,0 @@
-targets:
-  $default:
-    builders:
-      build_web_compilers|entrypoint:
-        generate_for:
-          include: ["test/**_test.dart"]
-          exclude: ["test/all_tests.*", "test/mirrors_test.*"]

--- a/build.yaml
+++ b/build.yaml
@@ -3,4 +3,5 @@ targets:
     builders:
       build_web_compilers|entrypoint:
         generate_for:
+          include: ["test/**_test.dart"]
           exclude: ["test/all_tests.*", "test/mirrors_test.*"]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ dev_dependencies:
   test: '>=1.2.0 <2.0.0'
 #DDC_TEST:  build_runner: ^1.3.1
 #DDC_TEST:  build_test: ^0.10.6
-#DDC_TEST:  build_web_compilers: ^1.2.0
+#DDC_TEST:  build_web_compilers: ^2.0.0
 
 # The above dependencies are used for running the dartdevc_test task on Travis.
 # Since build_runner indirectly depends on quiver, we patch these in at test


### PR DESCRIPTION
The existing generate_for was overriding the default glob to also include the `lib` directory, which was slowing down initial builds a tiny bit for all users who have a transitive dep on this package. (it wouldn't actually compile them since they aren't apps, but it was running on all dart files in lib and skipping them).