### PR TITLE
Instrument pending timers in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 2.0.4
+
+   * Added `FakeAsync.pendingTimersDebugInfo`.
+
 #### 2.0.3
 
    * Do not cache failed `ifAbsent` calls in `MapCache`.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 2.0.3
+version: 2.0.4
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -572,7 +572,7 @@ main() {
         });
       });
 
-      test('it should report the number of pending periodic timers', () {
+      test('should report the number of pending periodic timers', () {
         new FakeAsync().run((async) {
           expect(async.periodicTimerCount, 0);
           Timer timer =
@@ -587,7 +587,7 @@ main() {
         });
       });
 
-      test('it should report the number of pending non periodic timers', () {
+      test('should report the number of pending non periodic timers', () {
         new FakeAsync().run((async) {
           expect(async.nonPeriodicTimerCount, 0);
           Timer timer = new Timer(const Duration(minutes: 30), () {});
@@ -598,6 +598,34 @@ main() {
           expect(async.nonPeriodicTimerCount, 1);
           timer.cancel();
           expect(async.nonPeriodicTimerCount, 0);
+        });
+      });
+
+      test('should report debugging information of pending timers', () {
+        FakeAsync().run((async) {
+          expect(async.pendingTimersDebugInfo, isEmpty);
+          // Use `dynamic` to subvert the type checks and access `_FakeAsync`
+          // internals.
+          dynamic nonPeriodic = Timer(const Duration(seconds: 1), () {});
+          dynamic periodic =
+              Timer.periodic(const Duration(seconds: 2), (Timer timer) {});
+          final debugInfo = async.pendingTimersDebugInfo;
+          expect(debugInfo.length, 2);
+          expect(
+            debugInfo,
+            containsAll([
+              nonPeriodic.debugInfo,
+              periodic.debugInfo,
+            ]),
+          );
+
+          const thisFileName = 'fake_async_test.dart';
+          expect(nonPeriodic.debugInfo, contains(':01.0'));
+          expect(nonPeriodic.debugInfo, contains('periodic: false'));
+          expect(nonPeriodic.debugInfo, contains(thisFileName));
+          expect(periodic.debugInfo, contains(':02.0'));
+          expect(periodic.debugInfo, contains('periodic: true'));
+          expect(periodic.debugInfo, contains(thisFileName));
         });
       });
     });


### PR DESCRIPTION
Flutter widget tests assert if a test completes with timers still
pending.  However, it can be hard to diagnose where a pending timer
came from.  For example, a widget might consume a third-party library
that internally uses a timer.

To facilitate this, modify quiver's FakeAsync to store
StackTrace.current when constructing each _FakeTimer.  Add a
pendingTimersDebugInfo getter to to report this.

Fixes #421.