### PR TITLE
Update Travis xvfb configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,24 +35,20 @@ jobs:
       env: SHARD=dart2js_test
       addons:
         chrome: stable
-      before_install:
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
-        - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"
+      services:
+        - xvfb
       script: ./tool/travis/task.sh dart2js_test
 
     - stage: testing
       env: SHARD=dartdevc_test
       addons:
         chrome: stable
-      before_install:
-        - export DISPLAY=:99.0
-        - sh -e /etc/init.d/xvfb start
-        - "t=0; until (xdpyinfo -display :99 &> /dev/null || test $t -gt 10); do sleep 1; let t=$t+1; done"
-      script: ./tool/travis/task.sh dartdevc_test
       cache:
         directories:
           - .dart_tool
+      services:
+        - xvfb
+      script: ./tool/travis/task.sh dartdevc_test
 
     # coverage.
     - stage: coverage


### PR DESCRIPTION
Travis CI released an update to their Xenial build environemnt, which
introduced a new way to start up XVFB for front-end builds. You now
simply add

    services:
      - xvfb

to your Travis shard config instead.

See: https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-update-86123