### PR TITLE
Add `sumInts` and `sumDoubles`

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ false.
 
 `listsEqual`, `mapsEqual` and `setsEqual` check collections for equality.
 
+`sumInts` and `sumDoubles` compute sum of numbers.
+
 `LruMap` is a map that removes the least recently used item when a threshold
 length is exceeded.
 

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -98,3 +98,13 @@ int indexOf<T>(Iterable<T> elements, bool predicate(T element)) {
   }
   return -1;
 }
+
+/// Returns the sum of the given integers.
+int sumInts(Iterable<int> numbers) {
+  return numbers.fold(0, (rs, n) => rs + n);
+}
+
+/// Returns the sum of the given doubles.
+double sumDoubles(Iterable<double> numbers) {
+  return numbers.fold(0, (rs, n) => rs + n);
+}

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -82,4 +82,26 @@ main() {
       expect(indexOf<bool>([], (_) => true), -1);
     });
   });
+
+  group('sumInts', () {
+    test('returns 0 if input is empty', () {
+      expect(sumInts(<int>[]), isZero);
+    });
+
+    test('returns sum if input is not empty', () {
+      expect(sumInts([-1, 1]), isZero);
+      expect(sumInts([1, 2, 3]), 6);
+    });
+  });
+
+  group('sumDoubles', () {
+    test('returns 0 if input is empty', () {
+      expect(sumDoubles(<double>[]), isZero);
+    });
+
+    test('returns sum if input is not empty', () {
+      expect(sumDoubles([-2.0, 2.0]), isZero);
+      expect(sumDoubles([2.0, 3.0, 4.0]), 9.0);
+    });
+  });
 }


### PR DESCRIPTION
I found the sum operation is very frequently used in my projects so I want to add it here.
I tried to implement just 1 generic function like this:

```dart
T sum<T extends num>(Iterable<T> numbers) {
  ...
}
```

Howerver, I have a trouble when the input is empty. In such case, I need to return a 'zero' value. But there is no common 'zero' for both `int` and `double`.