### PR TITLE
Add new string methods `ifBlank()` and `ifEmpty()`

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -32,6 +32,12 @@ bool isEmpty(String s) => s == null || s.isEmpty;
 /// Returns [true] if [s] is a not empty string.
 bool isNotEmpty(String s) => s != null && s.isNotEmpty;
 
+/// Returns [s] if it's non-blank, otherwise returns [dfault]
+String ifBlank(String s, String dfault) => isBlank(s) ? dfault : s;
+
+/// Returns [s] if it's non-empty, otherwise returns [dfault]
+String ifEmpty(String s, String dfault) => isEmpty(s) ? dfault : s;
+
 /// Returns a string with characters from the given [s] in reverse order.
 ///
 /// NOTE: without full support for unicode composed character sequences,

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -48,6 +48,21 @@ main() {
     });
   });
 
+  group('ifBlank', () {
+    test('should return default value for null input', () {
+      expect(ifBlank(null, 'default'), 'default');
+    });
+    test('should return default value for empty string input', () {
+      expect(ifBlank('', 'default'), 'default');
+    });
+    test('should return default value for white-space-only string input', () {
+      expect(ifBlank(' \n\t\r\f', 'default'), 'default');
+    });
+    test('should return original value for non-whitespace string input', () {
+      expect(ifBlank('hello', 'default'), 'hello');
+    });
+  });
+
   group('isEmpty', () {
     test('should consider null to be empty', () {
       expect(isEmpty(null), isTrue);
@@ -75,6 +90,21 @@ main() {
     });
     test('should consider non-whitespace string to be not empty', () {
       expect(isNotEmpty('hello'), isTrue);
+    });
+  });
+
+  group('ifEmpty', () {
+    test('should return default value for null input', () {
+      expect(ifEmpty(null, 'default'), 'default');
+    });
+    test('should return default value for empty string input', () {
+      expect(ifEmpty('', 'default'), 'default');
+    });
+    test('should return original value for white-space-only string input', () {
+      expect(ifEmpty(' ', 'default'), ' ');
+    });
+    test('should return original value for non-whitespace string input', () {
+      expect(ifEmpty('hello', 'default'), 'hello');
     });
   });
 


### PR DESCRIPTION
New string methods `ifBlank()` and `ifEmpty()` provide an easier way to set default values for empty and blank strings. These could be considered complimentary to Dart's native `??` operator (or the `??` operator could be considered as the `ifNull()` counterpart to these methods).

Example:
```dart
function doSomething(String myValue) {
  myValue ??= 'my default value'; // -- this works great for handling potential null-values
}
```

```patch
function doSomething(String myValue) {
-  myValue = (isNotEmpty(myValue) ? myValue : 'my default value');
+  myValue = ifEmpty(myValue, 'my default value'); // -- now we can treat empty/blank values in a similar way
}
```