### PR TITLE
Use = for default values of named parameters

### DIFF
--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -45,11 +45,11 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   /// Note: This iterator allows you to walk the entire set. It does not
   /// present a subview.
   BidirectionalIterator<V> fromIterator(V anchor,
-      {bool reversed: false, bool inclusive: true});
+      {bool reversed = false, bool inclusive = true});
 
   /// Search the tree for the matching [object] or the [nearestOption]
   /// if missing.  See [TreeSearch].
-  V nearest(V object, {TreeSearch nearestOption: TreeSearch.NEAREST});
+  V nearest(V object, {TreeSearch nearestOption = TreeSearch.NEAREST});
 
   @override
   // ignore: override_on_non_overriding_method
@@ -664,7 +664,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     return null;
   }
 
-  V nearest(V object, {TreeSearch nearestOption: TreeSearch.NEAREST}) {
+  V nearest(V object, {TreeSearch nearestOption = TreeSearch.NEAREST}) {
     AvlNode<V> found = _searchNearest(object, option: nearestOption);
     return (found != null) ? found.object : null;
   }
@@ -673,7 +673,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   /// NOTE: [BinaryTree.comparator] needs to have finer granulatity than -1,0,1
   /// in order for this to return something that's meaningful.
   AvlNode<V> _searchNearest(V element,
-      {TreeSearch option: TreeSearch.NEAREST}) {
+      {TreeSearch option = TreeSearch.NEAREST}) {
     if (element == null || _root == null) {
       return null;
     }

--- a/lib/src/time/clock.dart
+++ b/lib/src/time/clock.dart
@@ -56,12 +56,12 @@ class Clock {
   /// amount of time is the sum of individual parts. Parts are compatible with
   /// ones defined in [Duration].
   DateTime ago(
-          {int days: 0,
-          int hours: 0,
-          int minutes: 0,
-          int seconds: 0,
-          int milliseconds: 0,
-          int microseconds: 0}) =>
+          {int days = 0,
+          int hours = 0,
+          int minutes = 0,
+          int seconds = 0,
+          int milliseconds = 0,
+          int microseconds = 0}) =>
       agoBy(new Duration(
           days: days,
           hours: hours,


### PR DESCRIPTION
Replaces pre-Dart 2.0 style named parameter default syntax (which used a
colon to separate the parameter from its default value), to the
preferred Dart 2.0 syntax.