### PR TITLE
Replace use of isInstanceOf with isA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 2.1.0-dev
+
+   * Upgraded matcher dependency lower-bound from 0.10.0 to 0.12.5 to migrate
+     from `isInstanceOf` to `isA` in tests.
+
 #### 2.0.5 - 2019-08-06
 
    * Added `isNotBlank` to strings library.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 2.0.5
+version: 2.1.0-dev
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>
@@ -22,7 +22,7 @@ homepage: https://github.com/google/quiver-dart
 environment:
   sdk: '>=2.0.0-dev.61 <3.0.0'
 dependencies:
-  matcher: '>=0.10.0 <0.13.0'
+  matcher: '>=0.12.5 <0.13.0'
   meta: '>=1.0.0 <2.0.0'
 dev_dependencies:
   path: '>=1.0.0 <2.0.0'

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -41,15 +41,13 @@ main() {
     });
 
     test('should throw when adding a null key or value', () {
-      expect(() => map[null] = v1, throwsA(new isInstanceOf<ArgumentError>()));
-      expect(() => map[k1] = null, throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map[null] = v1, throwsA(isA<ArgumentError>()));
+      expect(() => map[k1] = null, throwsA(isA<ArgumentError>()));
     });
 
     test('should throw when adding a null key or value via its inverse', () {
-      expect(() => map.inverse[null] = k1,
-          throwsA(new isInstanceOf<ArgumentError>()));
-      expect(() => map.inverse[v1] = null,
-          throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map.inverse[null] = k1, throwsA(isA<ArgumentError>()));
+      expect(() => map.inverse[v1] = null, throwsA(isA<ArgumentError>()));
     });
 
     test('should not be empty after adding a mapping', () {
@@ -121,7 +119,7 @@ main() {
 
     test('should throw on overwriting unmapped keys with a mapped value', () {
       map[k1] = v1;
-      expect(() => map[k2] = v1, throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map[k2] = v1, throwsA(isA<ArgumentError>()));
       expect(map.containsKey(k2), false);
       expect(map.inverse.containsValue(k2), false);
     });
@@ -130,8 +128,7 @@ main() {
         'should throw on overwriting unmapped keys with a mapped value via inverse',
         () {
       map[k1] = v1;
-      expect(() => map.inverse[v2] = k1,
-          throwsA(new isInstanceOf<ArgumentError>()));
+      expect(() => map.inverse[v2] = k1, throwsA(isA<ArgumentError>()));
       expect(map.containsValue(v2), false);
       expect(map.inverse.containsKey(v2), false);
     });
@@ -373,14 +370,14 @@ main() {
 
     test('should throw on adding from another map with duplicate values', () {
       expect(() => map.addAll({k1: v1, k2: v2, k3: v2}),
-          throwsA(new isInstanceOf<ArgumentError>()));
+          throwsA(isA<ArgumentError>()));
     });
 
     test(
         'should throw on adding from another map with duplicate values via inverse',
         () {
       expect(() => map.inverse.addAll({v1: k1, v2: k2, v3: k2}),
-          throwsA(new isInstanceOf<ArgumentError>()));
+          throwsA(isA<ArgumentError>()));
     });
 
     test('should return the number of key-value pairs as its length', () {

--- a/test/core/hash_test.dart
+++ b/test/core/hash_test.dart
@@ -20,21 +20,21 @@ import 'package:test/test.dart';
 main() {
   test('hashObjects should return an int', () {
     int h = hashObjects(['123', 456]);
-    expect(h, new isInstanceOf<int>());
+    expect(h, isA<int>());
   });
 
   test('hash2 should return an int', () {
     int h = hash2('123', 456);
-    expect(h, new isInstanceOf<int>());
+    expect(h, isA<int>());
   });
 
   test('hash3 should return an int', () {
     int h = hash3('123', 456, true);
-    expect(h, new isInstanceOf<int>());
+    expect(h, isA<int>());
   });
 
   test('hash4 should return an int', () {
     int h = hash4('123', 456, true, []);
-    expect(h, new isInstanceOf<int>());
+    expect(h, isA<int>());
   });
 }

--- a/test/mirrors_test.dart
+++ b/test/mirrors_test.dart
@@ -67,9 +67,8 @@ main() {
     test('should return a member of a class', () {
       var mirror = reflect(new Foo()).type;
       expect(getDeclaration(mirror, const Symbol('toString')),
-          new isInstanceOf<MethodMirror>());
-      expect(getDeclaration(mirror, const Symbol('a')),
-          new isInstanceOf<VariableMirror>());
+          isA<MethodMirror>());
+      expect(getDeclaration(mirror, const Symbol('a')), isA<VariableMirror>());
     });
   });
 

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -46,7 +46,7 @@ main() {
       test('should throw when called with a negative duration', () {
         expect(() {
           new FakeAsync().elapseBlocking(const Duration(days: -1));
-        }, throwsA(new isInstanceOf<ArgumentError>()));
+        }, throwsA(isA<ArgumentError>()));
       });
     });
 
@@ -61,7 +61,7 @@ main() {
       test('should throw ArgumentError when called with a negative duration',
           () {
         expect(() => new FakeAsync().elapse(const Duration(days: -1)),
-            throwsA(new isInstanceOf<ArgumentError>()));
+            throwsA(isA<ArgumentError>()));
       });
 
       test('should throw when called before previous call is complete', () {
@@ -75,7 +75,7 @@ main() {
             }
           });
           async.elapse(elapseBy);
-          expect(error, new isInstanceOf<StateError>());
+          expect(error, isA<StateError>());
         });
       });
 
@@ -332,7 +332,7 @@ main() {
               timeout = err;
             });
             async.elapse(elapseBy);
-            expect(timeout, new isInstanceOf<TimeoutException>());
+            expect(timeout, isA<TimeoutException>());
             completer.complete();
           });
         });
@@ -366,7 +366,7 @@ main() {
             expect(events, [0]);
             async.elapse(const Duration(minutes: 1));
             expect(errors, hasLength(1));
-            expect(errors.first, new isInstanceOf<TimeoutException>());
+            expect(errors.first, isA<TimeoutException>());
             subscription.cancel();
             controller.close();
           });


### PR DESCRIPTION
The unconventially-named `isInstanceOf` class used by tests was
deprecated upstream and replaced by the `isA` function.