### PR TITLE
Deprecate doWhileAsync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 2.1.1-dev
+
+   * Deprecate `doWhileAsync`. Existing callers should migrate to
+     `Future.doWhile()` from `dart:async`.
+
 #### 2.1.0 - 2019-10-28
 
    * Upgraded matcher dependency lower-bound from 0.10.0 to 0.12.5 to migrate

--- a/lib/src/async/iteration.dart
+++ b/lib/src/async/iteration.dart
@@ -28,6 +28,7 @@ typedef Future<T> AsyncCombiner<T, E>(T previous, E e);
 ///
 /// The Future returned completes to [true] if the entire iterable was
 /// processed, otherwise [false].
+@Deprecated('Use Future.doWhile from dart:async. Will be removed in 3.0.0.')
 Future<bool> doWhileAsync<T>(
         Iterable<T> iterable, AsyncAction<bool, T> action) =>
     _doWhileAsync(iterable.iterator, action);


### PR DESCRIPTION
`doWhileAsync` is redundant with `Future.doWhile()`. We will remove this
in Quiver 3.0.0.