### PR TITLE
Add analysis_options.yaml

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,2 +1,166 @@
 analyzer:
-  strong-mode: true
+  # ENABLE strong-mode:
+  # ENABLE   implicit-dynamic: false
+  errors:
+    # treat missing required parameters as a warning (not a hint)
+    missing_required_param: warning
+    # treat missing returns as a warning (not a hint)
+    missing_return: warning
+    # allow having TODOs in the code
+    todo: ignore
+    # Ignore analyzer hints for updating pubspecs when using Future or
+    # Stream and not importing dart:async
+    # Please see https://github.com/flutter/flutter/pull/24528 for details.
+    sdk_version_async_exported_from_core: ignore
+
+linter:
+  rules:
+    # these rules are documented on and in the same order as
+    # the Dart Lint rules page to make maintenance easier
+    # https://github.com/dart-lang/linter/blob/master/example/all.yaml
+    # ENABLE - always_declare_return_types
+    # ENABLE - always_put_control_body_on_new_line
+    - always_put_required_named_parameters_first
+    # ENABLE - always_require_non_null_named_parameters
+    # ENABLE - always_specify_types
+    # ENABLE - annotate_overrides
+    # - avoid_annotating_with_dynamic # conflicts with always_specify_types
+    # ENABLE - avoid_as
+    # ENABLE - avoid_bool_literals_in_conditional_expressions
+    # - avoid_catches_without_on_clauses # we do this commonly
+    # - avoid_catching_errors # we do this commonly
+    - avoid_classes_with_only_static_members
+    # - avoid_double_and_int_checks # only useful when targeting JS runtime
+    - avoid_empty_else
+    - avoid_field_initializers_in_const_classes
+    # ENABLE - avoid_function_literals_in_foreach_calls
+    # - avoid_implementing_value_types # not yet tested
+    # ENABLE - avoid_init_to_null
+    # - avoid_js_rounded_ints # only useful when targeting JS runtime
+    - avoid_null_checks_in_equality_operators
+    # - avoid_positional_boolean_parameters # not yet tested
+    # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
+    - avoid_relative_lib_imports
+    # ENABLE - avoid_renaming_method_parameters
+    # ENABLE - avoid_return_types_on_setters
+    # - avoid_returning_null # there are plenty of valid reasons to return null
+    # - avoid_returning_null_for_future # not yet tested
+    - avoid_returning_null_for_void
+    # - avoid_returning_this # there are plenty of valid reasons to return this
+    # - avoid_setters_without_getters # not yet tested
+    # - avoid_shadowing_type_parameters # not yet tested
+    # - avoid_single_cascade_in_expression_statements # not yet tested
+    - avoid_slow_async_io
+    - avoid_types_as_parameter_names
+    # - avoid_types_on_closure_parameters # conflicts with always_specify_types
+    - avoid_unused_constructor_parameters
+    - avoid_void_async
+    - await_only_futures
+    - camel_case_types
+    - cancel_subscriptions
+    # - cascade_invocations # not yet tested
+    # - close_sinks # not reliable enough
+    # - comment_references # blocked on https://github.com/flutter/flutter/issues/20765
+    # - constant_identifier_names # needs an opt-out https://github.com/dart-lang/linter/issues/204
+    - control_flow_in_finally
+    # - curly_braces_in_flow_control_structures # not yet tested
+    # - diagnostic_describe_all_properties # not yet tested
+    # ENABLE - directives_ordering
+    - empty_catches
+    - empty_constructor_bodies
+    # ENABLE - empty_statements
+    # - file_names # not yet tested
+    # ENABLE - flutter_style_todos
+    # ENABLE - hash_and_equals
+    - implementation_imports
+    # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
+    - iterable_contains_unrelated_type
+    # - join_return_with_assignment # not yet tested
+    - library_names
+    # ENABLE - library_prefixes
+    # - lines_longer_than_80_chars # not yet tested
+    - list_remove_unrelated_type
+    # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
+    - no_adjacent_strings_in_list
+    - no_duplicate_case_values
+    # ENABLE - non_constant_identifier_names
+    # - null_closures  # not yet tested
+    # - omit_local_variable_types # opposite of always_specify_types
+    # - one_member_abstracts # too many false positives
+    # - only_throw_errors # https://github.com/flutter/flutter/issues/5792
+    - overridden_fields
+    - package_api_docs
+    - package_names
+    - package_prefixed_library_names
+    # - parameter_assignments # we do this commonly
+    - prefer_adjacent_string_concatenation
+    - prefer_asserts_in_initializer_lists
+    # - prefer_asserts_with_message # not yet tested
+    # ENABLE - prefer_collection_literals
+    # ENABLE - prefer_conditional_assignment
+    # ENABLE - prefer_const_constructors
+    - prefer_const_constructors_in_immutables
+    # ENABLE - prefer_const_declarations
+    - prefer_const_literals_to_create_immutables
+    # - prefer_constructors_over_static_methods # not yet tested
+    - prefer_contains
+    # - prefer_double_quotes # opposite of prefer_single_quotes
+    # ENABLE - prefer_equal_for_default_values
+    # - prefer_expression_function_bodies # conflicts with https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo#consider-using--for-short-functions-and-methods
+    # ENABLE - prefer_final_fields
+    # - prefer_final_in_for_each # not yet tested
+    # ENABLE - prefer_final_locals
+    # - prefer_for_elements_to_map_fromIterable # not yet tested
+    # ENABLE - prefer_foreach
+    # - prefer_function_declarations_over_variables # not yet tested
+    # ENABLE - prefer_generic_function_type_aliases
+    - prefer_if_elements_to_conditional_expressions
+    # ENABLE - prefer_if_null_operators
+    # ENABLE - prefer_initializing_formals
+    - prefer_inlined_adds
+    # - prefer_int_literals # not yet tested
+    # - prefer_interpolation_to_compose_strings # not yet tested
+    # ENABLE - prefer_is_empty
+    - prefer_is_not_empty
+    - prefer_iterable_whereType
+    # - prefer_mixin # https://github.com/dart-lang/language/issues/32
+    # - prefer_null_aware_operators # disable until NNBD, see https://github.com/flutter/flutter/pull/32711#issuecomment-492930932
+    # ENABLE - prefer_single_quotes
+    - prefer_spread_collections
+    # ENABLE - prefer_typing_uninitialized_variables
+    # ENABLE - prefer_void_to_null
+    # - provide_deprecation_message # not yet tested
+    # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
+    - recursive_getters
+    # ENABLE - slash_for_doc_comments
+    # - sort_child_properties_last # not yet tested
+    # ENABLE - sort_constructors_first
+    - sort_pub_dependencies
+    - sort_unnamed_constructors_first
+    # ENABLE - test_types_in_equals
+    - throw_in_finally
+    # - type_annotate_public_apis # subset of always_specify_types
+    # ENABLE - type_init_formals
+    # - unawaited_futures # too many false positives
+    # - unnecessary_await_in_return # not yet tested
+    # ENABLE - unnecessary_brace_in_string_interps
+    # ENABLE - unnecessary_const
+    - unnecessary_getters_setters
+    # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
+    # ENABLE - unnecessary_new
+    - unnecessary_null_aware_assignments
+    - unnecessary_null_in_if_null_operators
+    # ENABLE - unnecessary_overrides
+    # ENABLE - unnecessary_parenthesis
+    # ENABLE - unnecessary_statements
+    # ENABLE - unnecessary_this
+    # ENABLE - unrelated_type_equality_checks
+    # - unsafe_html # not yet tested
+    - use_full_hex_values_for_flutter_colors
+    # - use_function_type_syntax_for_parameters # not yet tested
+    - use_rethrow_when_possible
+    # - use_setters_to_change_properties # not yet tested
+    # - use_string_buffers # has false positives: https://github.com/dart-lang/sdk/issues/34182
+    # - use_to_and_as_if_applicable # has false positives, so we prefer to catch this by code-review
+    - valid_regexps
+    # - void_checks # not yet tested


### PR DESCRIPTION
Adds a copy of Flutter's current analysis_options.yaml with all
non-passing lints commented out with 'ENABLE'. Flutter enables a
generally well-though-out set of lints, and the authors are familiar
with this style.