### PR TITLE
Add explicit return types where missing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -18,7 +18,7 @@ linter:
     # these rules are documented on and in the same order as
     # the Dart Lint rules page to make maintenance easier
     # https://github.com/dart-lang/linter/blob/master/example/all.yaml
-    # ENABLE - always_declare_return_types
+    - always_declare_return_types
     # ENABLE - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
     # ENABLE - always_require_non_null_named_parameters

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -24,7 +24,8 @@ part 'src/core/optional.dart';
 /// [ArgumentError].
 ///
 /// Note: if [o1] is an [Optional], this can be accomplished with `o1.or(o2)`.
-firstNonNull(o1, o2, [o3, o4]) {
+dynamic firstNonNull(o1, o2, [o3, o4]) {
+  // TODO(cbracken): make this generic.
   if (o1 != null) return o1;
   if (o2 != null) return o2;
   if (o3 != null) return o3;

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -57,13 +57,13 @@ class CountdownTimer extends Stream<CountdownTimer> {
 
   bool get isRunning => _stopwatch.isRunning;
 
-  cancel() {
+  void cancel() {
     _stopwatch.stop();
     _timer.cancel();
     _controller.close();
   }
 
-  _tick(Timer timer) {
+  void _tick(Timer timer) {
     var t = remaining;
     _controller.add(this);
     // timers may have a 4ms resolution

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -58,7 +58,7 @@ class FutureStream<T> extends Stream<T> {
     }
   }
 
-  _onListen() {
+  void _onListen() {
     _future.then((stream) {
       if (_controller == null) return;
       _subscription = stream.listen(_controller.add,
@@ -66,7 +66,7 @@ class FutureStream<T> extends Stream<T> {
     });
   }
 
-  _onCancel() {
+  void _onCancel() {
     if (_subscription != null) _subscription.cancel();
     _subscription = null;
     _controller = null;

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -90,13 +90,13 @@ class Metronome extends Stream<DateTime> {
       _controller.stream.listen(onData,
           onError: onError, onDone: onDone, cancelOnError: cancelOnError);
 
-  _startTimer(DateTime now) {
+  void _startTimer(DateTime now) {
     var delay =
         _intervalMs - ((now.millisecondsSinceEpoch - _anchorMs) % _intervalMs);
     _timer = new Timer(new Duration(milliseconds: delay), _tickDate);
   }
 
-  _tickDate() {
+  void _tickDate() {
     // Hey now, what's all this hinky clock.now() calls? Simple, if the workers
     // on the receiving end of _controller.add() take a non-zero amount of time
     // to do their thing (e.g. rendering a large scene with canvas), the next

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -350,7 +350,7 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
 
   _WrappedIterable(this._map, this._key, this._delegate);
 
-  _addToMap() => _map[_key] = _delegate;
+  void _addToMap() => _map[_key] = _delegate;
 
   /// Ensures we hold an up-to-date delegate. In the case where all mappings
   /// for _key are removed from the multimap, the Iterable referenced by
@@ -358,7 +358,7 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
   /// addition via the multimap triggers the creation of a new Iterable, and
   /// the empty delegate we hold would be stale. As such, we check the
   /// underlying map and update our delegate when the one we hold is empty.
-  _syncDelegate() {
+  void _syncDelegate() {
     if (_delegate.isEmpty) {
       var updated = _map[_key];
       if (updated != null) {

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -25,7 +25,8 @@ class IndexedValue<V> {
 
   IndexedValue(this.index, this.value);
 
-  operator ==(o) => o is IndexedValue && o.index == index && o.value == value;
+  bool operator ==(o) =>
+      o is IndexedValue && o.index == index && o.value == value;
   int get hashCode => index * 31 + value.hashCode;
   String toString() => '($index, $value)';
 }

--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -190,7 +190,7 @@ class _FakeAsync implements FakeAsync {
       _timers.map((timer) => '${timer.debugInfo}').toList(growable: false);
 
   @override
-  run(callback(FakeAsync self)) {
+  dynamic run(callback(FakeAsync self)) {
     if (_zone == null) {
       _zone = Zone.current.fork(specification: _zoneSpec);
     }
@@ -224,7 +224,7 @@ class _FakeAsync implements FakeAsync {
         _microtasks.add(microtask);
       });
 
-  _drainTimersWhile(bool predicate(_FakeTimer timer)) {
+  void _drainTimersWhile(bool predicate(_FakeTimer timer)) {
     _drainMicrotasks();
     _FakeTimer next;
     while ((next = _getNextTimer()) != null && predicate(next)) {
@@ -233,7 +233,7 @@ class _FakeAsync implements FakeAsync {
     }
   }
 
-  _elapseTo(Duration to) {
+  void _elapseTo(Duration to) {
     if (to > _elapsed) {
       _elapsed = to;
     }
@@ -251,7 +251,7 @@ class _FakeAsync implements FakeAsync {
         : _timers.reduce((t1, t2) => t1._nextCall <= t2._nextCall ? t1 : t2);
   }
 
-  _runTimer(_FakeTimer timer) {
+  void _runTimer(_FakeTimer timer) {
     assert(timer.isActive);
     _elapseTo(timer._nextCall);
     if (timer._isPeriodic) {
@@ -263,15 +263,15 @@ class _FakeAsync implements FakeAsync {
     }
   }
 
-  _drainMicrotasks() {
+  void _drainMicrotasks() {
     while (_microtasks.isNotEmpty) {
       _microtasks.removeFirst()();
     }
   }
 
-  _hasTimer(_FakeTimer timer) => _timers.contains(timer);
+  bool _hasTimer(_FakeTimer timer) => _timers.contains(timer);
 
-  _cancelTimer(_FakeTimer timer) => _timers.remove(timer);
+  void _cancelTimer(_FakeTimer timer) => _timers.remove(timer);
 }
 
 class _FakeTimer implements Timer {
@@ -297,7 +297,7 @@ class _FakeTimer implements Timer {
 
   bool get isActive => _time._hasTimer(this);
 
-  cancel() => _time._cancelTimer(this);
+  void cancel() => _time._cancelTimer(this);
 
   @override
   // TODO: Dart 2.0 requires this method to be implemented.

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -27,7 +27,7 @@ import 'strings_test.dart' as strings;
 import 'testing/all_tests.dart' as testing;
 import 'time/all_tests.dart' as time;
 
-main() {
+void main() {
   async.main();
   cache.main();
   check.main();

--- a/test/async/all_tests.dart
+++ b/test/async/all_tests.dart
@@ -24,7 +24,7 @@ import 'metronome_test.dart' as metronome;
 import 'stream_buffer_test.dart' as stream_buffer;
 import 'stream_router_test.dart' as stream_router;
 
-main() {
+void main() {
   collect.main();
   concat.main();
   countdown_timer.main();

--- a/test/async/collect_test.dart
+++ b/test/async/collect_test.dart
@@ -20,7 +20,7 @@ import 'dart:math';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('collect', () {
     test('should produce no events for no futures',
         () => collect([]).toList().then((events) => expect(events, isEmpty)));
@@ -53,7 +53,7 @@ main() {
 
       var collected = collect(futures);
 
-      decrementParallel(_) {
+      void decrementParallel(_) {
         eventCount++;
         currentParallel--;
       }

--- a/test/async/concat_test.dart
+++ b/test/async/concat_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('concat', () {
     test('should produce no events for no streams',
         () => concat([]).toList().then((events) => expect(events, isEmpty)));

--- a/test/async/countdown_timer_test.dart
+++ b/test/async/countdown_timer_test.dart
@@ -20,7 +20,7 @@ import 'package:quiver/time.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:quiver/testing/time.dart';
 
-main() {
+void main() {
   group('CountdownTimer', () {
     test('should countdown', () {
       new FakeAsync().run((FakeAsync async) {

--- a/test/async/enumerate_test.dart
+++ b/test/async/enumerate_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('enumerate', () {
     test('should add indices to its argument', () {
       var controller = new StreamController<String>();

--- a/test/async/future_stream_test.dart
+++ b/test/async/future_stream_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('FutureStream', () {
     test('should forward an event', () {
       var completer = new Completer<Stream<String>>();

--- a/test/async/iteration_test.dart
+++ b/test/async/iteration_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('doWhileAsync', () {
     test('should process the entier iterable if action returns true', () {
       var items = [];

--- a/test/async/metronome_test.dart
+++ b/test/async/metronome_test.dart
@@ -19,7 +19,7 @@ import 'package:quiver/async.dart';
 import 'package:quiver/time.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group("Metronome", () {
     test("delivers events as expected", () {
       new FakeAsync().run((async) {

--- a/test/async/stream_router_test.dart
+++ b/test/async/stream_router_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/async.dart';
 
-main() {
+void main() {
   group('StreamRouter', () {
     test('should route an event to the correct stream', () {
       var controller = new StreamController<String>();

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -18,7 +18,7 @@ import 'dart:async';
 import 'package:test/test.dart';
 import 'package:quiver/cache.dart';
 
-main() {
+void main() {
   group('MapCache', () {
     MapCache<String, String> cache;
 

--- a/test/check_test.dart
+++ b/test/check_test.dart
@@ -17,7 +17,7 @@ library quiver.check_test;
 import 'package:quiver/check.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('checkArgument', () {
     group('success', () {
       test('simple', () => checkArgument(true));
@@ -30,7 +30,7 @@ main() {
     });
 
     group('failure', () {
-      checkArgumentShouldFail(Function f, [String expectedMessage]) {
+      void checkArgumentShouldFail(Function f, [String expectedMessage]) {
         try {
           f();
           fail('Should have thrown an ArgumentError');
@@ -80,7 +80,7 @@ main() {
     });
 
     group('failure', () {
-      checkStateShouldFail(Function f, [String expectedMessage]) {
+      void checkStateShouldFail(Function f, [String expectedMessage]) {
         if (expectedMessage == null) expectedMessage = 'failed precondition';
         try {
           f();
@@ -126,7 +126,7 @@ main() {
     });
 
     group('failure', () {
-      checkNotNullShouldFail(Function f, [String expectedMessage]) {
+      void checkNotNullShouldFail(Function f, [String expectedMessage]) {
         if (expectedMessage == null) expectedMessage = 'null pointer';
         try {
           f();
@@ -175,7 +175,7 @@ main() {
     });
 
     group('failure', () {
-      checkListIndexShouldFail(int index, int size,
+      void checkListIndexShouldFail(int index, int size,
           [message, String expectedMessage]) {
         try {
           checkListIndex(index, size, message: message);

--- a/test/collection/all_tests.dart
+++ b/test/collection/all_tests.dart
@@ -25,7 +25,7 @@ import 'delegates/map_test.dart' as map;
 import 'delegates/queue_test.dart' as queue;
 import 'delegates/set_test.dart' as setTest;
 
-main() {
+void main() {
   bimap.main();
   collection.main();
   lru_map.main();

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -17,7 +17,7 @@ library quiver.collection.bimap_test;
 import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('BiMap', () {
     test('should construct a HashBiMap', () {
       expect(new BiMap() is HashBiMap, true);

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -17,7 +17,7 @@ library quiver.collection.collection_test;
 import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('listsEqual', () {
     test('return true for equal lists', () {
       expect(listsEqual(null, null), isTrue);

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -17,7 +17,7 @@ library quiver.collection.treeset_test;
 import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group("TreeSet", () {
     group("when empty", () {
       TreeSet<num> tree;

--- a/test/core/all_tests.dart
+++ b/test/core/all_tests.dart
@@ -18,7 +18,7 @@ import 'core_test.dart' as core;
 import 'hash_test.dart' as hash;
 import 'optional_test.dart' as optional;
 
-main() {
+void main() {
   core.main();
   hash.main();
   optional.main();

--- a/test/core/core_test.dart
+++ b/test/core/core_test.dart
@@ -17,7 +17,7 @@ library quiver.core_test;
 import 'package:quiver/core.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('firstNonNull', () {
     test("should return the first argument if it isn't null", () {
       expect(firstNonNull(1, 2), 1);

--- a/test/core/hash_test.dart
+++ b/test/core/hash_test.dart
@@ -17,7 +17,7 @@ library quiver.core.hash_test;
 import 'package:quiver/core.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   test('hashObjects should return an int', () {
     int h = hashObjects(['123', 456]);
     expect(h, isA<int>());

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -17,7 +17,7 @@ library quiver.core.optional_test;
 import 'package:quiver/core.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('Optional', () {
     test('absent should be not present and not gettable', () {
       Optional absent = new Optional<int>.absent();

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -23,7 +23,7 @@ import 'package:path/path.dart' as path;
 import 'package:quiver/io.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('byteStreamToString', () {
     test('should decode UTF8 text by default', () {
       var string = '箙、靫';

--- a/test/iterables/all_tests.dart
+++ b/test/iterables/all_tests.dart
@@ -26,7 +26,7 @@ import 'generating_iterable_test.dart' as generating_iterable;
 import 'range_test.dart' as range;
 import 'zip_test.dart' as zip;
 
-main() {
+void main() {
   concat.main();
   count.main();
   cycle.main();

--- a/test/iterables/concat_test.dart
+++ b/test/iterables/concat_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.concat_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('concat', () {
     test('should handle empty input iterables', () {
       expect(concat([]), isEmpty);

--- a/test/iterables/count_test.dart
+++ b/test/iterables/count_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.count_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('count', () {
     test("should create an infinite sequence starting at 0 given no args", () {
       expect(count().first, 0);

--- a/test/iterables/cycle_test.dart
+++ b/test/iterables/cycle_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.cycle_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('cycle', () {
     test("should create an empty iterable given an empty iterable", () {
       expect(cycle([]), []);

--- a/test/iterables/enumerate_test.dart
+++ b/test/iterables/enumerate_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.enumerate_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('enumerate', () {
     test("should add indices to its argument", () {
       var e = enumerate(['a', 'b', 'c']);

--- a/test/iterables/generating_iterable_test.dart
+++ b/test/iterables/generating_iterable_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.property_iterable_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('GeneratingIterable', () {
     test("should create an empty iterable for a null start object", () {
       var iterable = new GeneratingIterable(() => null, (n) => null);

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -30,7 +30,7 @@ class NaturalNumberIterator implements Iterator<int> {
   }
 }
 
-main() {
+void main() {
   group('InfiniteIterable', () {
     NaturalNumberIterable it;
 

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.merge_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('merge', () {
     test("should merge no iterables into empty iterable", () {
       expect(merge([]), []);

--- a/test/iterables/min_max_test.dart
+++ b/test/iterables/min_max_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.min_max_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('max', () {
     test('should return the maximum element', () {
       expect(max([2, 5, 1, 4]), 5);

--- a/test/iterables/partition_test.dart
+++ b/test/iterables/partition_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.partition_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('partition', () {
     test('should throw when size is <= 0', () {
       expect(() => partition([1, 2, 3], 0), throwsArgumentError);

--- a/test/iterables/range_test.dart
+++ b/test/iterables/range_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.range_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('range', () {
     test("should create an empty iterator if stop is 0", () {
       expect(range(0), []);

--- a/test/iterables/zip_test.dart
+++ b/test/iterables/zip_test.dart
@@ -17,7 +17,7 @@ library quiver.iterables.zip_test;
 import 'package:test/test.dart';
 import 'package:quiver/iterables.dart';
 
-main() {
+void main() {
   group('zip', () {
     test("should create an empty iterable if given no iterables", () {
       expect(zip([]), []);

--- a/test/mirrors_test.dart
+++ b/test/mirrors_test.dart
@@ -21,7 +21,7 @@ import 'dart:mirrors';
 import 'package:quiver/mirrors.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('getTypeName', () {
     test('should return the qualified name for a type', () {
       expect(getTypeName(Object), const Symbol('dart.core.Object'));
@@ -92,6 +92,6 @@ main() {
 
 class Foo extends IterableBase implements Comparable {
   String a;
-  get iterator => null;
+  Iterator get iterator => null;
   int compareTo(o) => 0;
 }

--- a/test/pattern/all_tests.dart
+++ b/test/pattern/all_tests.dart
@@ -17,7 +17,7 @@ library quiver.pattern.all_tests;
 import 'glob_test.dart' as glob;
 import 'pattern_test.dart' as pattern;
 
-main() {
+void main() {
   glob.main();
   pattern.main();
 }

--- a/test/pattern/glob_test.dart
+++ b/test/pattern/glob_test.dart
@@ -17,7 +17,7 @@ library quiver.patttern.glob_test;
 import 'package:test/test.dart';
 import 'package:quiver/pattern.dart';
 
-main() {
+void main() {
   group('Glob', () {
     test('should match "*" against sequences of word chars', () {
       expectGlob("*.html", matches: [
@@ -53,7 +53,8 @@ main() {
   });
 }
 
-expectGlob(String pattern, {List<String> matches, List<String> nonMatches}) {
+void expectGlob(String pattern,
+    {List<String> matches, List<String> nonMatches}) {
   var glob = new Glob(pattern);
   for (var str in matches) {
     expect(glob.hasMatch(str), true);

--- a/test/pattern/pattern_test.dart
+++ b/test/pattern/pattern_test.dart
@@ -19,7 +19,7 @@ import 'package:quiver/pattern.dart';
 
 final _specialChars = r'\^$.|+[](){}';
 
-main() {
+void main() {
   group('escapeRegex', () {
     test('should escape special characters', () {
       for (var c in _specialChars.split('')) {
@@ -73,7 +73,7 @@ main() {
   });
 }
 
-expectMatch(Pattern pattern, String str, int start, List<String> matches) {
+void expectMatch(Pattern pattern, String str, int start, List<String> matches) {
   var actual = pattern.allMatches(str, start).map((m) => m.group(0)).toList();
   expect(actual, matches);
 }

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -17,7 +17,7 @@ library quiver.strings;
 import 'package:quiver/strings.dart';
 import 'package:test/test.dart' hide isEmpty, isNotEmpty;
 
-main() {
+void main() {
   group('isBlank', () {
     test('should consider null a blank', () {
       expect(isBlank(null), isTrue);

--- a/test/testing/all_tests.dart
+++ b/test/testing/all_tests.dart
@@ -17,7 +17,7 @@ library quiver.testing.all_tests;
 import 'async/all_tests.dart' as async;
 import 'equality/all_tests.dart' as equality;
 
-main() {
+void main() {
   async.main();
   equality.main();
 }

--- a/test/testing/async/all_tests.dart
+++ b/test/testing/async/all_tests.dart
@@ -16,6 +16,6 @@ library quiver.testing.async.all_tests;
 
 import 'fake_async_test.dart' as fake_async;
 
-main() {
+void main() {
   fake_async.main();
 }

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -19,7 +19,7 @@ import 'dart:async';
 import 'package:quiver/testing/async.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('FakeAsync', () {
     var initialTime = new DateTime(2000);
     var elapseBy = const Duration(days: 1);
@@ -207,7 +207,7 @@ main() {
           new FakeAsync().run((async) {
             var microtaskCalls = 0;
             var timerCalls = 0;
-            scheduleMicrotasks() {
+            void scheduleMicrotasks() {
               for (int i = 0; i < 5; i++) {
                 scheduleMicrotask(() => microtaskCalls++);
               }
@@ -494,7 +494,7 @@ main() {
       test('should timeout a chain of timers', () {
         new FakeAsync().run((async) {
           int count = 0;
-          createTimer() {
+          void createTimer() {
             new Future.delayed(const Duration(minutes: 30), () {
               count++;
               createTimer();
@@ -541,7 +541,7 @@ main() {
         new FakeAsync().run((async) {
           final log = [];
           int count = 0;
-          createTimer() {
+          void createTimer() {
             new Future.delayed(const Duration(minutes: 30), () {
               log.add(count);
               count++;

--- a/test/testing/equality/all_tests.dart
+++ b/test/testing/equality/all_tests.dart
@@ -16,6 +16,6 @@ library quiver.testing.util.all_tests;
 
 import 'equality_test.dart' as equality_test;
 
-main() {
+void main() {
   equality_test.main();
 }

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -17,7 +17,7 @@ library quiver.testing.util.equalstester;
 import 'package:quiver/testing/equality.dart';
 import 'package:test/test.dart';
 
-main() {
+void main() {
   group('expectEquals', () {
     _ValidTestObject reference;
     _ValidTestObject equalObject1;

--- a/test/time/all_tests.dart
+++ b/test/time/all_tests.dart
@@ -16,6 +16,6 @@ library quiver.time.all_tests;
 
 import 'clock_test.dart' as clock;
 
-main() {
+void main() {
   clock.main();
 }

--- a/test/time/clock_test.dart
+++ b/test/time/clock_test.dart
@@ -19,11 +19,11 @@ import 'package:quiver/time.dart';
 
 Clock from(int y, int m, int d) => new Clock.fixed(new DateTime(y, m, d));
 
-expectDate(DateTime date, int y, [int m = 1, int d = 1]) {
+void expectDate(DateTime date, int y, [int m = 1, int d = 1]) {
   expect(date, new DateTime(y, m, d));
 }
 
-main() {
+void main() {
   group('clock', () {
     Clock subject;
 


### PR DESCRIPTION
Enables the always_declare_missing_return_types lint.