### PR TITLE
Eliminate use of 'as' casts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,7 @@ linter:
     # ENABLE - always_specify_types
     # ENABLE - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    # ENABLE - avoid_as
+    - avoid_as
     # ENABLE - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -91,7 +91,7 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
       var subsize = leftToRead > listCap ? listCap : leftToRead;
       if (chunk is List) {
         ret.setRange(follower, follower + subsize,
-            (chunk as List<T>).getRange(_offset, _offset + subsize));
+            chunk.getRange(_offset, _offset + subsize));
       } else {
         ret[follower] = chunk;
       }
@@ -99,7 +99,7 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
       _offset += subsize;
       _counter -= subsize;
       leftToRead -= subsize;
-      if (chunk is! List || _offset >= (chunk as List).length) {
+      if (!(chunk is List && _offset < chunk.length)) {
         _offset = 0;
         _chunks.removeAt(0);
       }

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -173,7 +173,7 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
       retValues.addAll(values);
       values.clear();
     }
-    return retValues as Iterable<V>;
+    return retValues;
   }
 
   void clear() {

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -407,7 +407,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   bool remove(Object item) {
     if (item is! V) return false;
 
-    AvlNode<V> x = _getNode(item as V);
+    AvlNode<V> x = _getNode(item);
     if (x != null) {
       _removeNode(x);
       return true;
@@ -652,7 +652,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     AvlNode<V> x = _root;
     int compare = 0;
     while (x != null) {
-      compare = comparator(element as V, x.object);
+      compare = comparator(element, x.object);
       if (compare == 0) {
         return x.object;
       } else if (compare < 0) {
@@ -730,7 +730,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
 
   /// See [IterableBase.contains]
   bool contains(Object object) {
-    AvlNode<V> x = _getNode(object as V);
+    AvlNode<V> x = _getNode(object);
     return x != null;
   }
 

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -63,7 +63,7 @@ class _EqualityGroupMatcher extends Matcher {
   @override
   bool matches(item, Map matchState) {
     try {
-      _verifyEqualityGroups(item as Map<String, List>, matchState);
+      _verifyEqualityGroups(item, matchState);
       return true;
     } on MatchError catch (e) {
       matchState[failureReason] = e.toString();

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -294,7 +294,7 @@ class _ValidTestObject {
     if (!(o is _ValidTestObject)) {
       return false;
     }
-    _ValidTestObject other = o as _ValidTestObject;
+    final _ValidTestObject other = o;
     if (aspect1 != other.aspect1) {
       return false;
     }
@@ -340,7 +340,7 @@ class _InconsistentHashCodeObject {
     if (!(o is _InconsistentHashCodeObject)) {
       return false;
     }
-    _InconsistentHashCodeObject other = o as _InconsistentHashCodeObject;
+    final _InconsistentHashCodeObject other = o;
     if (_aspect1 != other._aspect1) return false;
     if (_aspect2 != other._aspect2) return false;
     return true;
@@ -364,7 +364,7 @@ class _InvalidHashCodeObject {
     if (!(o is _InvalidHashCodeObject)) {
       return false;
     }
-    _InvalidHashCodeObject other = o as _InvalidHashCodeObject;
+    final _InvalidHashCodeObject other = o;
     if (_aspect1 != other._aspect1) return false;
     if (_aspect2 != other._aspect2) return false;
     return true;


### PR DESCRIPTION
Enables the avoid_as lint.