### PR TITLE
Add override annotations where missing

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -23,7 +23,7 @@ linter:
     - always_put_required_named_parameters_first
     # ENABLE - always_require_non_null_named_parameters
     # ENABLE - always_specify_types
-    # ENABLE - annotate_overrides
+    - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
     - avoid_as
     # ENABLE - avoid_bool_literals_in_conditional_expressions

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -66,6 +66,7 @@ class Method /* implements Function */ {
 
   Method(this.mirror, this.symbol);
 
+  @override
   dynamic noSuchMethod(Invocation i) {
     if (i.isMethod && i.memberName == const Symbol('call')) {
       if (i.namedArguments != null && i.namedArguments.isNotEmpty) {

--- a/lib/pattern.dart
+++ b/lib/pattern.dart
@@ -42,6 +42,7 @@ class _MultiPattern extends Pattern {
 
   _MultiPattern(this.include, {this.exclude});
 
+  @override
   Iterable<Match> allMatches(String str, [int start = 0]) {
     final _allMatches = <Match>[];
     for (var pattern in include) {
@@ -60,6 +61,7 @@ class _MultiPattern extends Pattern {
     return _allMatches;
   }
 
+  @override
   Match matchAsPrefix(String str, [int start = 0]) {
     return allMatches(str)
         .firstWhere((match) => match.start == start, orElse: () => null);

--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -39,6 +39,7 @@ class _ConcatStream<T> extends Stream<T> {
 
   _ConcatStream(Iterable<Stream<T>> streams) : _streams = streams;
 
+  @override
   StreamSubscription<T> listen(void onData(T data),
       {Function onError, void onDone(), bool cancelOnError}) {
     cancelOnError = true == cancelOnError;

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -47,6 +47,7 @@ class CountdownTimer extends Stream<CountdownTimer> {
     _stopwatch.start();
   }
 
+  @override
   StreamSubscription<CountdownTimer> listen(void onData(CountdownTimer event),
           {Function onError, void onDone(), bool cancelOnError}) =>
       _controller.stream.listen(onData, onError: onError, onDone: onDone);

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -72,11 +72,13 @@ class FutureStream<T> extends Stream<T> {
     _controller = null;
   }
 
+  @override
   StreamSubscription<T> listen(void onData(T event),
       {Function onError, void onDone(), bool cancelOnError}) {
     return _controller.stream.listen(onData,
         onError: onError, onDone: onDone, cancelOnError: cancelOnError);
   }
 
+  @override
   bool get isBroadcast => _controller.stream.isBroadcast;
 }

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -59,6 +59,7 @@ class Metronome extends Stream<DateTime> {
   final int _intervalMs;
   final int _anchorMs;
 
+  @override
   bool get isBroadcast => true;
 
   Metronome.epoch(Duration interval, {Clock clock: const Clock()})
@@ -85,6 +86,7 @@ class Metronome extends Stream<DateTime> {
         });
   }
 
+  @override
   StreamSubscription<DateTime> listen(void onData(DateTime event),
           {Function onError, void onDone(), bool cancelOnError}) =>
       _controller.stream.listen(onData,

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -22,6 +22,7 @@ class UnderflowError extends Error {
   /// The [message] describes the underflow.
   UnderflowError([this.message]);
 
+  @override
   String toString() {
     if (message != null) {
       return "StreamBuffer Underflow: $message";
@@ -168,6 +169,7 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
     _readers.clear();
   }
 
+  @override
   Future close() {
     var ret;
     if (_sub != null) {

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -30,6 +30,7 @@ class MapCache<K, V> implements Cache<K, V> {
     return new MapCache<K, V>(map: new LruMap(maximumSize: maximumSize));
   }
 
+  @override
   Future<V> get(K key, {Loader<K, V> ifAbsent}) async {
     if (_map.containsKey(key)) {
       return _map[key];
@@ -55,10 +56,12 @@ class MapCache<K, V> implements Cache<K, V> {
     return null;
   }
 
+  @override
   Future<Null> set(K key, V value) async {
     _map[key] = value;
   }
 
+  @override
   Future<Null> invalidate(K key) async {
     _map.remove(key);
   }

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -29,6 +29,7 @@ abstract class BiMap<K, V> implements Map<K, V> {
   /// Throws [ArgumentError] if an association involving [value] exists in the
   /// map; otherwise, the association is inserted, overwriting any existing
   /// association for the key.
+  @override
   void operator []=(K key, V value);
 
   /// Replaces any existing associations(s) involving key and value.
@@ -51,25 +52,47 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   HashBiMap() : this._from(new HashMap(), new HashMap());
   HashBiMap._from(this._map, this._inverse);
 
+  @override
   V operator [](Object key) => _map[key];
+
+  @override
   void operator []=(K key, V value) {
     _add(key, value, false);
   }
 
+  @override
   void replace(K key, V value) {
     _add(key, value, true);
   }
 
+  @override
   void addAll(Map<K, V> other) => other.forEach((k, v) => _add(k, v, false));
+
+  @override
   bool containsKey(Object key) => _map.containsKey(key);
+
+  @override
   bool containsValue(Object value) => _inverse.containsKey(value);
+
+  @override
   void forEach(void f(K key, V value)) => _map.forEach(f);
+
+  @override
   bool get isEmpty => _map.isEmpty;
+
+  @override
   bool get isNotEmpty => _map.isNotEmpty;
+
+  @override
   Iterable<K> get keys => _map.keys;
+
+  @override
   int get length => _map.length;
+
+  @override
   Iterable<V> get values => _inverse.keys;
 
+  @override
   BiMap<V, K> get inverse => _cached ??= new HashBiMap._from(_inverse, _map);
 
   @override
@@ -80,9 +103,8 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
@@ -93,6 +115,7 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   Map<K2, V2> map<K2, V2>(MapEntry<K2, V2> transform(K key, V value)) =>
       _map.map(transform);
 
+  @override
   V putIfAbsent(K key, V ifAbsent()) {
     var value = _map[key];
     if (value != null) return value;
@@ -100,6 +123,7 @@ class HashBiMap<K, V> implements BiMap<K, V> {
     return null;
   }
 
+  @override
   V remove(Object key) {
     _inverse.remove(_map[key]);
     return _map.remove(key);
@@ -109,13 +133,6 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   void removeWhere(bool test(K key, V value)) {
     _inverse.removeWhere((v, k) => test(k, v));
     _map.removeWhere(test);
-  }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Map<K2, V2> retype<K2, V2>() {
-    throw new UnimplementedError("retype");
   }
 
   @override
@@ -137,6 +154,7 @@ class HashBiMap<K, V> implements BiMap<K, V> {
     }
   }
 
+  @override
   void clear() {
     _map.clear();
     _inverse.clear();

--- a/lib/src/collection/delegates/iterable.dart
+++ b/lib/src/collection/delegates/iterable.dart
@@ -27,85 +27,103 @@ part of quiver.collection;
 abstract class DelegatingIterable<E> implements Iterable<E> {
   Iterable<E> get delegate;
 
+  @override
   bool any(bool test(E element)) => delegate.any(test);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   bool contains(Object element) => delegate.contains(element);
 
+  @override
   E elementAt(int index) => delegate.elementAt(index);
 
+  @override
   bool every(bool test(E element)) => delegate.every(test);
 
+  @override
   Iterable<T> expand<T>(Iterable<T> f(E element)) => delegate.expand(f);
 
+  @override
   E get first => delegate.first;
 
+  @override
   E firstWhere(bool test(E element), {E orElse()}) =>
       delegate.firstWhere(test, orElse: orElse);
 
+  @override
   T fold<T>(T initialValue, T combine(T previousValue, E element)) =>
       delegate.fold(initialValue, combine);
 
   @override
   Iterable<E> followedBy(Iterable<E> other) => delegate.followedBy(other);
 
+  @override
   void forEach(void f(E element)) => delegate.forEach(f);
 
+  @override
   bool get isEmpty => delegate.isEmpty;
 
+  @override
   bool get isNotEmpty => delegate.isNotEmpty;
 
+  @override
   Iterator<E> get iterator => delegate.iterator;
 
+  @override
   String join([String separator = ""]) => delegate.join(separator);
 
+  @override
   E get last => delegate.last;
 
+  @override
   E lastWhere(bool test(E element), {E orElse()}) =>
       delegate.lastWhere(test, orElse: orElse);
 
+  @override
   int get length => delegate.length;
 
+  @override
   Iterable<T> map<T>(T f(E e)) => delegate.map(f);
 
+  @override
   E reduce(E combine(E value, E element)) => delegate.reduce(combine);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Iterable<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   E get single => delegate.single;
 
+  @override
   E singleWhere(bool test(E element), {E orElse()}) =>
       delegate.singleWhere(test, orElse: orElse);
 
+  @override
   Iterable<E> skip(int n) => delegate.skip(n);
 
+  @override
   Iterable<E> skipWhile(bool test(E value)) => delegate.skipWhile(test);
 
+  @override
   Iterable<E> take(int n) => delegate.take(n);
 
+  @override
   Iterable<E> takeWhile(bool test(E value)) => delegate.takeWhile(test);
 
+  @override
   List<E> toList({bool growable: true}) => delegate.toList(growable: growable);
 
+  @override
   Set<E> toSet() => delegate.toSet();
 
+  @override
   Iterable<E> where(bool test(E element)) => delegate.where(test);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("whereType");
   }
 }

--- a/lib/src/collection/delegates/list.dart
+++ b/lib/src/collection/delegates/list.dart
@@ -26,10 +26,13 @@ part of quiver.collection;
 ///     }
 abstract class DelegatingList<E> extends DelegatingIterable<E>
     implements List<E> {
+  @override
   List<E> get delegate;
 
+  @override
   E operator [](int index) => delegate[index];
 
+  @override
   void operator []=(int index, E value) {
     delegate[index] = value;
   }
@@ -37,49 +40,48 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   @override
   List<E> operator +(List<E> other) => delegate + other;
 
+  @override
   void add(E value) => delegate.add(value);
 
+  @override
   void addAll(Iterable<E> iterable) => delegate.addAll(iterable);
 
+  @override
   Map<int, E> asMap() => delegate.asMap();
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   DelegatingList<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  DelegatingList<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   void clear() => delegate.clear();
 
+  @override
   void fillRange(int start, int end, [E fillValue]) =>
       delegate.fillRange(start, end, fillValue);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_setter
   void set first(E element) {
     if (this.isEmpty) throw new RangeError.index(0, this);
     this[0] = element;
   }
 
+  @override
   Iterable<E> getRange(int start, int end) => delegate.getRange(start, end);
 
+  @override
   int indexOf(E element, [int start = 0]) => delegate.indexOf(element, start);
 
   @override
   int indexWhere(bool test(E element), [int start = 0]) =>
       delegate.indexWhere(test, start);
 
+  @override
   void insert(int index, E element) => delegate.insert(index, element);
 
+  @override
   void insertAll(int index, Iterable<E> iterable) =>
       delegate.insertAll(index, iterable);
 
@@ -89,6 +91,7 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
     this[this.length - 1] = element;
   }
 
+  @override
   int lastIndexOf(E element, [int start]) =>
       delegate.lastIndexOf(element, start);
 
@@ -96,37 +99,51 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   int lastIndexWhere(bool test(E element), [int start]) =>
       delegate.lastIndexWhere(test, start);
 
+  @override
   void set length(int newLength) {
     delegate.length = newLength;
   }
 
+  @override
   bool remove(Object value) => delegate.remove(value);
 
+  @override
   E removeAt(int index) => delegate.removeAt(index);
 
+  @override
   E removeLast() => delegate.removeLast();
 
+  @override
   void removeRange(int start, int end) => delegate.removeRange(start, end);
 
+  @override
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
+  @override
   void replaceRange(int start, int end, Iterable<E> iterable) =>
       delegate.replaceRange(start, end, iterable);
 
+  @override
   void retainWhere(bool test(E element)) => delegate.retainWhere(test);
 
+  @override
   Iterable<E> get reversed => delegate.reversed;
 
+  @override
   void setAll(int index, Iterable<E> iterable) =>
       delegate.setAll(index, iterable);
 
+  @override
   void setRange(int start, int end, Iterable<E> iterable,
           [int skipCount = 0]) =>
       delegate.setRange(start, end, iterable, skipCount);
 
+  @override
   void shuffle([Random random]) => delegate.shuffle(random);
 
+  @override
   void sort([int compare(E a, E b)]) => delegate.sort(compare);
 
+  @override
   List<E> sublist(int start, [int end]) => delegate.sublist(start, end);
 }

--- a/lib/src/collection/delegates/map.dart
+++ b/lib/src/collection/delegates/map.dart
@@ -27,95 +27,95 @@ part of quiver.collection;
 abstract class DelegatingMap<K, V> implements Map<K, V> {
   Map<K, V> get delegate;
 
+  @override
   V operator [](Object key) => delegate[key];
 
+  @override
   void operator []=(K key, V value) {
     delegate[key] = value;
   }
 
+  @override
   void addAll(Map<K, V> other) => delegate.addAll(other);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void addEntries(Iterable<Object> entries) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     // Change Iterable<Object> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
     throw new UnimplementedError("addEntries");
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   void clear() => delegate.clear();
 
+  @override
   bool containsKey(Object key) => delegate.containsKey(key);
 
+  @override
   bool containsValue(Object value) => delegate.containsValue(value);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_getter
   Iterable<Null> get entries {
+    // TODO: Dart 2.0 requires this method to be implemented.
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
     throw new UnimplementedError("entries");
   }
 
+  @override
   void forEach(void f(K key, V value)) => delegate.forEach(f);
 
+  @override
   bool get isEmpty => delegate.isEmpty;
 
+  @override
   bool get isNotEmpty => delegate.isNotEmpty;
 
+  @override
   Iterable<K> get keys => delegate.keys;
 
+  @override
   int get length => delegate.length;
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
     throw new UnimplementedError("map");
   }
 
+  @override
   V putIfAbsent(K key, V ifAbsent()) => delegate.putIfAbsent(key, ifAbsent);
 
+  @override
   V remove(Object key) => delegate.remove(key);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void removeWhere(bool test(K key, V value)) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("removeWhere");
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Map<K2, V2> retype<K2, V2>() {
-    throw new UnimplementedError("retype");
-  }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   V update(K key, V update(V value), {V ifAbsent()}) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("update");
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   void updateAll(V update(K key, V value)) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("updateAll");
   }
 
+  @override
   Iterable<V> get values => delegate.values;
 }

--- a/lib/src/collection/delegates/queue.dart
+++ b/lib/src/collection/delegates/queue.dart
@@ -26,39 +26,42 @@ part of quiver.collection;
 ///     }
 abstract class DelegatingQueue<E> extends DelegatingIterable<E>
     implements Queue<E> {
+  @override
   Queue<E> get delegate;
 
+  @override
   void add(E value) => delegate.add(value);
 
+  @override
   void addAll(Iterable<E> iterable) => delegate.addAll(iterable);
 
+  @override
   void addFirst(E value) => delegate.addFirst(value);
 
+  @override
   void addLast(E value) => delegate.addLast(value);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   DelegatingQueue<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   void clear() => delegate.clear();
 
+  @override
   bool remove(Object object) => delegate.remove(object);
 
+  @override
   E removeFirst() => delegate.removeFirst();
 
+  @override
   E removeLast() => delegate.removeLast();
 
+  @override
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
-  void retainWhere(bool test(E element)) => delegate.retainWhere(test);
-
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  DelegatingQueue<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
+  void retainWhere(bool test(E element)) => delegate.retainWhere(test);
 }

--- a/lib/src/collection/delegates/set.dart
+++ b/lib/src/collection/delegates/set.dart
@@ -26,45 +26,51 @@ part of quiver.collection;
 ///     }
 abstract class DelegatingSet<E> extends DelegatingIterable<E>
     implements Set<E> {
+  @override
   Set<E> get delegate;
 
+  @override
   bool add(E value) => delegate.add(value);
 
+  @override
   void addAll(Iterable<E> elements) => delegate.addAll(elements);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   DelegatingSet<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  DelegatingSet<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   void clear() => delegate.clear();
 
+  @override
   bool containsAll(Iterable<Object> other) => delegate.containsAll(other);
 
+  @override
   Set<E> difference(Set<Object> other) => delegate.difference(other);
 
+  @override
   Set<E> intersection(Set<Object> other) => delegate.intersection(other);
 
+  @override
   E lookup(Object object) => delegate.lookup(object);
 
+  @override
   bool remove(Object value) => delegate.remove(value);
 
+  @override
   void removeAll(Iterable<Object> elements) => delegate.removeAll(elements);
 
+  @override
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
+  @override
   void retainAll(Iterable<Object> elements) => delegate.retainAll(elements);
 
+  @override
   void retainWhere(bool test(E element)) => delegate.retainWhere(test);
 
+  @override
   Set<E> union(Set<E> other) => delegate.union(other);
 }

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -84,9 +84,8 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
       entries.forEach((entry) => this[entry.key] = entry.value);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   LinkedLruHashMap<K2, V2> cast<K2, V2>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
@@ -147,9 +146,8 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   Iterable<V> get values => _iterable().map((e) => e.value);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> map<K2, V2>(Object transform(K key, V value)) {
+    // TODO: Dart 2.0 requires this method to be implemented.
     // Change Object to MapEntry<K2, V2> when
     // the MapEntry class has been added.
     throw new UnimplementedError("map");
@@ -249,13 +247,6 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
     for (var key in keysToRemove) {
       remove(key);
     }
-  }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  LinkedLruHashMap<K2, V2> retype<K2, V2>() {
-    throw new UnimplementedError("retype");
   }
 
   @override

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -126,10 +126,14 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
   bool _remove(C iterable, Object value);
   Iterable<V> _wrap(Object key, C iterable);
 
+  @override
   bool containsValue(Object value) => values.contains(value);
+  @override
   bool containsKey(Object key) => _map.keys.contains(key);
+  @override
   bool contains(Object key, Object value) => _map[key]?.contains(value) == true;
 
+  @override
   Iterable<V> operator [](Object key) {
     var values = _map[key];
     if (values == null) {
@@ -138,11 +142,13 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     return _wrap(key, values);
   }
 
+  @override
   void add(K key, V value) {
     _map.putIfAbsent(key, _create);
     _add(_map[key], value);
   }
 
+  @override
   void addValues(K key, Iterable<V> values) {
     _map.putIfAbsent(key, _create);
     _addAll(_map[key], values);
@@ -156,8 +162,10 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
   ///
   /// This implementation iterates through each key of [other] and adds the
   /// associated values to this instance via [addValues].
+  @override
   void addAll(Multimap<K, V> other) => other.forEachKey(addValues);
 
+  @override
   bool remove(Object key, V value) {
     if (!_map.containsKey(key)) return false;
     bool removed = _remove(_map[key], value);
@@ -165,6 +173,7 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     return removed;
   }
 
+  @override
   Iterable<V> removeAll(Object key) {
     // Cast to dynamic to remove warnings
     var values = _map.remove(key) as dynamic;
@@ -176,24 +185,32 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     return retValues;
   }
 
+  @override
   void clear() {
     _map.forEach((K key, Iterable<V> value) => _clear(value));
     _map.clear();
   }
 
+  @override
   void forEachKey(void f(K key, C value)) => _map.forEach(f);
 
+  @override
   void forEach(void f(K key, V value)) {
     _map.forEach((K key, Iterable<V> values) {
       values.forEach((V value) => f(key, value));
     });
   }
 
+  @override
   Iterable<K> get keys => _map.keys;
+  @override
   Iterable<V> get values => _map.values.expand((x) => x);
   Iterable<Iterable<V>> get _groupedValues => _map.values;
+  @override
   int get length => _map.length;
+  @override
   bool get isEmpty => _map.isEmpty;
+  @override
   bool get isNotEmpty => _map.isNotEmpty;
 }
 
@@ -225,8 +242,11 @@ class ListMultimap<K, V> extends _BaseMultimap<K, V, List<V>> {
   @override
   List<V> _wrap(Object key, List<V> iterable) =>
       new _WrappedList(_map, key, iterable);
+  @override
   List<V> operator [](Object key) => super[key];
+  @override
   List<V> removeAll(Object key) => super.removeAll(key);
+  @override
   Map<K, List<V>> asMap() => new _WrappedMap<K, V, List<V>>(this);
 }
 
@@ -258,8 +278,11 @@ class SetMultimap<K, V> extends _BaseMultimap<K, V, Set<V>> {
   @override
   Set<V> _wrap(Object key, Iterable<V> iterable) =>
       new _WrappedSet(_map, key, iterable);
+  @override
   Set<V> operator [](Object key) => super[key];
+  @override
   Set<V> removeAll(Object key) => super.removeAll(key);
+  @override
   Map<K, Set<V>> asMap() => new _WrappedMap<K, V, Set<V>>(this);
 }
 
@@ -269,43 +292,49 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
 
   _WrappedMap(this._multimap);
 
+  @override
   C operator [](Object key) => _multimap[key];
 
+  @override
   void operator []=(K key, C value) {
     throw new UnsupportedError("Insert unsupported on map view");
   }
 
+  @override
   void addAll(Map<K, C> other) {
     throw new UnsupportedError("Insert unsupported on map view");
   }
 
+  @override
   C putIfAbsent(K key, C ifAbsent()) {
     throw new UnsupportedError("Insert unsupported on map view");
   }
 
+  @override
   void clear() => _multimap.clear();
+  @override
   bool containsKey(Object key) => _multimap.containsKey(key);
+  @override
   bool containsValue(Object value) => _multimap.containsValue(value);
+  @override
   void forEach(void f(K key, C value)) => _multimap.forEachKey(f);
+  @override
   bool get isEmpty => _multimap.isEmpty;
+  @override
   bool get isNotEmpty => _multimap.isNotEmpty;
+  @override
   Iterable<K> get keys => _multimap.keys;
+  @override
   int get length => _multimap.length;
+  @override
   C remove(Object key) => _multimap.removeAll(key);
+  @override
   Iterable<C> get values => _multimap._groupedValues;
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Map<K2, V2> cast<K2, V2>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
-  }
-
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Map<K2, V2> retype<K2, V2>() {
-    throw new UnimplementedError("retype");
   }
 
   @override
@@ -367,48 +396,55 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     }
   }
 
+  @override
   bool any(bool test(V element)) {
     _syncDelegate();
     return _delegate.any(test);
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   bool contains(Object element) {
     _syncDelegate();
     return _delegate.contains(element);
   }
 
+  @override
   V elementAt(int index) {
     _syncDelegate();
     return _delegate.elementAt(index);
   }
 
+  @override
   bool every(bool test(V element)) {
     _syncDelegate();
     return _delegate.every(test);
   }
 
+  @override
   Iterable<T> expand<T>(Iterable<T> f(V element)) {
     _syncDelegate();
     return _delegate.expand(f);
   }
 
+  @override
   V get first {
     _syncDelegate();
     return _delegate.first;
   }
 
+  @override
   V firstWhere(bool test(V element), {V orElse()}) {
     _syncDelegate();
     return _delegate.firstWhere(test, orElse: orElse);
   }
 
+  @override
   T fold<T>(T initialValue, T combine(T previousValue, V element)) {
     _syncDelegate();
     return _delegate.fold(initialValue, combine);
@@ -420,117 +456,129 @@ class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
     return _delegate.followedBy(other);
   }
 
+  @override
   void forEach(void f(V element)) {
     _syncDelegate();
     _delegate.forEach(f);
   }
 
+  @override
   bool get isEmpty {
     _syncDelegate();
     return _delegate.isEmpty;
   }
 
+  @override
   bool get isNotEmpty {
     _syncDelegate();
     return _delegate.isNotEmpty;
   }
 
+  @override
   Iterator<V> get iterator {
     _syncDelegate();
     return _delegate.iterator;
   }
 
+  @override
   String join([String separator = ""]) {
     _syncDelegate();
     return _delegate.join(separator);
   }
 
+  @override
   V get last {
     _syncDelegate();
     return _delegate.last;
   }
 
+  @override
   V lastWhere(bool test(V element), {V orElse()}) {
     _syncDelegate();
     return _delegate.lastWhere(test, orElse: orElse);
   }
 
+  @override
   int get length {
     _syncDelegate();
     return _delegate.length;
   }
 
+  @override
   Iterable<T> map<T>(T f(V element)) {
     _syncDelegate();
     return _delegate.map(f);
   }
 
+  @override
   V reduce(V combine(V value, V element)) {
     _syncDelegate();
     return _delegate.reduce(combine);
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Iterable<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   V get single {
     _syncDelegate();
     return _delegate.single;
   }
 
+  @override
   V singleWhere(bool test(V element), {V orElse()}) {
     _syncDelegate();
     return _delegate.singleWhere(test, orElse: orElse);
   }
 
+  @override
   Iterable<V> skip(int n) {
     _syncDelegate();
     return _delegate.skip(n);
   }
 
+  @override
   Iterable<V> skipWhile(bool test(V value)) {
     _syncDelegate();
     return _delegate.skipWhile(test);
   }
 
+  @override
   Iterable<V> take(int n) {
     _syncDelegate();
     return _delegate.take(n);
   }
 
+  @override
   Iterable<V> takeWhile(bool test(V value)) {
     _syncDelegate();
     return _delegate.takeWhile(test);
   }
 
+  @override
   List<V> toList({bool growable: true}) {
     _syncDelegate();
     return _delegate.toList(growable: growable);
   }
 
+  @override
   Set<V> toSet() {
     _syncDelegate();
     return _delegate.toSet();
   }
 
+  @override
   String toString() {
     _syncDelegate();
     return _delegate.toString();
   }
 
+  @override
   Iterable<V> where(bool test(V element)) {
     _syncDelegate();
     return _delegate.where(test);
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Iterable<T> whereType<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("whereType");
   }
 }
@@ -540,8 +588,10 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
   _WrappedList(Map<K, Iterable<V>> map, K key, List<V> delegate)
       : super(map, key, delegate);
 
+  @override
   V operator [](int index) => elementAt(index);
 
+  @override
   void operator []=(int index, V value) {
     _syncDelegate();
     _delegate[index] = value;
@@ -553,6 +603,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return _delegate + other;
   }
 
+  @override
   void add(V value) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -560,6 +611,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (wasEmpty) _addToMap();
   }
 
+  @override
   void addAll(Iterable<V> iterable) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -567,24 +619,26 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (wasEmpty) _addToMap();
   }
 
+  @override
   Map<int, V> asMap() {
     _syncDelegate();
     return _delegate.asMap();
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   List<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   void clear() {
     _syncDelegate();
     _delegate.clear();
     _map.remove(_key);
   }
 
+  @override
   void fillRange(int start, int end, [V fillValue]) {
     _syncDelegate();
     _delegate.fillRange(start, end, fillValue);
@@ -596,11 +650,13 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     this[0] = value;
   }
 
+  @override
   Iterable<V> getRange(int start, int end) {
     _syncDelegate();
     return _delegate.getRange(start, end);
   }
 
+  @override
   int indexOf(V element, [int start = 0]) {
     _syncDelegate();
     return _delegate.indexOf(element, start);
@@ -612,6 +668,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return _delegate.indexWhere(test, start);
   }
 
+  @override
   void insert(int index, V element) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -619,6 +676,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (wasEmpty) _addToMap();
   }
 
+  @override
   void insertAll(int index, Iterable<V> iterable) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -632,6 +690,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     this[this.length - 1] = value;
   }
 
+  @override
   int lastIndexOf(V element, [int start]) {
     _syncDelegate();
     return _delegate.lastIndexOf(element, start);
@@ -643,6 +702,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return _delegate.lastIndexWhere(test, start);
   }
 
+  @override
   void set length(int newLength) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -650,6 +710,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     if (wasEmpty) _addToMap();
   }
 
+  @override
   bool remove(Object value) {
     _syncDelegate();
     bool removed = _delegate.remove(value);
@@ -657,6 +718,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return removed;
   }
 
+  @override
   V removeAt(int index) {
     _syncDelegate();
     V removed = _delegate.removeAt(index);
@@ -664,6 +726,7 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return removed;
   }
 
+  @override
   V removeLast() {
     _syncDelegate();
     V removed = _delegate.removeLast();
@@ -671,24 +734,28 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
     return removed;
   }
 
+  @override
   void removeRange(int start, int end) {
     _syncDelegate();
     _delegate.removeRange(start, end);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void removeWhere(bool test(V element)) {
     _syncDelegate();
     _delegate.removeWhere(test);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void replaceRange(int start, int end, Iterable<V> iterable) {
     _syncDelegate();
     _delegate.replaceRange(start, end, iterable);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void retainWhere(bool test(V element)) {
     _syncDelegate();
     _delegate.retainWhere(test);
@@ -696,36 +763,35 @@ class _WrappedList<K, V> extends _WrappedIterable<K, V, List<V>>
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  List<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   Iterable<V> get reversed {
     _syncDelegate();
     return _delegate.reversed;
   }
 
+  @override
   void setAll(int index, Iterable<V> iterable) {
     _syncDelegate();
     _delegate.setAll(index, iterable);
   }
 
+  @override
   void setRange(int start, int end, Iterable<V> iterable, [int skipCount = 0]) {
     _syncDelegate();
   }
 
+  @override
   void shuffle([Random random]) {
     _syncDelegate();
     _delegate.shuffle(random);
   }
 
+  @override
   void sort([int compare(V a, V b)]) {
     _syncDelegate();
     _delegate.sort(compare);
   }
 
+  @override
   List<V> sublist(int start, [int end]) {
     _syncDelegate();
     return _delegate.sublist(start, end);
@@ -737,6 +803,7 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
   _WrappedSet(Map<K, Iterable<V>> map, K key, Iterable<V> delegate)
       : super(map, key, delegate);
 
+  @override
   bool add(V value) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -745,6 +812,7 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
     return wasAdded;
   }
 
+  @override
   void addAll(Iterable<V> elements) {
     _syncDelegate();
     var wasEmpty = _delegate.isEmpty;
@@ -753,38 +821,43 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   void clear() {
     _syncDelegate();
     _delegate.clear();
     _map.remove(_key);
   }
 
+  @override
   bool containsAll(Iterable<Object> other) {
     _syncDelegate();
     return _delegate.containsAll(other);
   }
 
+  @override
   Set<V> difference(Set<Object> other) {
     _syncDelegate();
     return _delegate.difference(other);
   }
 
+  @override
   Set<V> intersection(Set<Object> other) {
     _syncDelegate();
     return _delegate.intersection(other);
   }
 
+  @override
   V lookup(Object object) {
     _syncDelegate();
     return _delegate.lookup(object);
   }
 
+  @override
   bool remove(Object value) {
     _syncDelegate();
     bool removed = _delegate.remove(value);
@@ -792,24 +865,28 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
     return removed;
   }
 
+  @override
   void removeAll(Iterable<Object> elements) {
     _syncDelegate();
     _delegate.removeAll(elements);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void removeWhere(bool test(V element)) {
     _syncDelegate();
     _delegate.removeWhere(test);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void retainAll(Iterable<Object> elements) {
     _syncDelegate();
     _delegate.retainAll(elements);
     if (_delegate.isEmpty) _map.remove(_key);
   }
 
+  @override
   void retainWhere(bool test(V element)) {
     _syncDelegate();
     _delegate.retainWhere(test);
@@ -817,12 +894,6 @@ class _WrappedSet<K, V> extends _WrappedIterable<K, V, Set<V>>
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Set<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   Set<V> union(Set<V> other) {
     _syncDelegate();
     return _delegate.union(other);

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -19,6 +19,7 @@ part of quiver.collection;
 abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   final Comparator<V> comparator;
 
+  @override
   int get length;
 
   /// Create a new [TreeSet] with an ordering defined by [comparator] or the
@@ -31,6 +32,7 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   TreeSet._(this.comparator);
 
   /// Returns an [BidirectionalIterator] that iterates over this tree.
+  @override
   BidirectionalIterator<V> get iterator;
 
   /// Returns an [BidirectionalIterator] that iterates over this tree, in
@@ -52,12 +54,7 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   V nearest(V object, {TreeSearch nearestOption = TreeSearch.NEAREST});
 
   @override
-  // ignore: override_on_non_overriding_method
   Set<T> cast<T>();
-
-  @override
-  // ignore: override_on_non_overriding_method
-  Set<T> retype<T>();
 
   // TODO: toString or not toString, that is the question.
 }
@@ -142,11 +139,13 @@ class AvlTreeSet<V> extends TreeSet<V> {
   // Modification count to the tree, monotonically increasing
   int _modCount = 0;
 
+  @override
   int get length => _length;
 
   AvlTreeSet({Comparator<V> comparator}) : super._(comparator);
 
   /// Add the element to the tree.
+  @override
   bool add(V element) {
     if (_root == null) {
       AvlNode<V> node = new AvlNode<V>(object: element);
@@ -376,6 +375,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     _rotateRight(node);
   }
 
+  @override
   bool addAll(Iterable<V> items) {
     bool modified = false;
     for (V ele in items) {
@@ -385,18 +385,19 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
   AvlTreeSet<T> cast<T>() {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("cast");
   }
 
+  @override
   void clear() {
     _length = 0;
     _root = null;
     ++_modCount;
   }
 
+  @override
   bool containsAll(Iterable<Object> items) {
     for (var ele in items) {
       if (!contains(ele)) return false;
@@ -404,6 +405,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     return true;
   }
 
+  @override
   bool remove(Object item) {
     if (item is! V) return false;
 
@@ -584,6 +586,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.removeAll]
+  @override
   void removeAll(Iterable items) {
     for (var ele in items) {
       remove(ele);
@@ -591,6 +594,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.retainAll]
+  @override
   void retainAll(Iterable<Object> elements) {
     List<V> chosen = <V>[];
     for (var target in elements) {
@@ -603,6 +607,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.retainWhere]
+  @override
   void retainWhere(bool test(V element)) {
     List<V> chosen = [];
     for (var target in this) {
@@ -614,14 +619,8 @@ class AvlTreeSet<V> extends TreeSet<V> {
     addAll(chosen);
   }
 
-  @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_method
-  Set<T> retype<T>() {
-    throw new UnimplementedError("retype");
-  }
-
   /// See [Set.removeWhere]
+  @override
   void removeWhere(bool test(V element)) {
     List<V> damned = [];
     for (var target in this) {
@@ -633,6 +632,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [IterableBase.first]
+  @override
   V get first {
     if (_root == null) return null;
     AvlNode<V> min = _root.minimumNode;
@@ -640,6 +640,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [IterableBase.last]
+  @override
   V get last {
     if (_root == null) return null;
     AvlNode<V> max = _root.maximumNode;
@@ -647,6 +648,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.lookup]
+  @override
   V lookup(Object element) {
     if (element is! V || _root == null) return null;
     AvlNode<V> x = _root;
@@ -664,6 +666,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     return null;
   }
 
+  @override
   V nearest(V object, {TreeSearch nearestOption = TreeSearch.NEAREST}) {
     AvlNode<V> found = _searchNearest(object, option: nearestOption);
     return (found != null) ? found.object : null;
@@ -716,19 +719,23 @@ class AvlTreeSet<V> extends TreeSet<V> {
   //
 
   /// See [IterableBase.iterator]
+  @override
   BidirectionalIterator<V> get iterator => new _AvlTreeIterator._(this);
 
   /// See [TreeSet.reverseIterator]
+  @override
   BidirectionalIterator<V> get reverseIterator =>
       new _AvlTreeIterator._(this, reversed: true);
 
   /// See [TreeSet.fromIterator]
+  @override
   BidirectionalIterator<V> fromIterator(V anchor,
           {bool reversed: false, bool inclusive: true}) =>
       new _AvlTreeIterator<V>._(this,
           anchorObject: anchor, reversed: reversed, inclusive: inclusive);
 
   /// See [IterableBase.contains]
+  @override
   bool contains(Object object) {
     AvlNode<V> x = _getNode(object);
     return x != null;
@@ -739,6 +746,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   //
 
   /// See [Set.intersection]
+  @override
   Set<V> intersection(Set<Object> other) {
     TreeSet<V> set = new TreeSet(comparator: comparator);
 
@@ -773,6 +781,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.union]
+  @override
   Set<V> union(Set<V> other) {
     TreeSet<V> set = new TreeSet(comparator: comparator);
 
@@ -809,6 +818,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
   }
 
   /// See [Set.difference]
+  @override
   Set<V> difference(Set<Object> other) {
     TreeSet<V> set = new TreeSet(comparator: comparator);
 
@@ -919,9 +929,13 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
     };
   }
 
+  @override
   V get current => (state != WALK || _current == null) ? null : _current.object;
 
+  @override
   bool moveNext() => _moveNext();
+
+  @override
   bool movePrevious() => _movePrevious();
 
   bool _moveNextNormal() {
@@ -973,13 +987,20 @@ class AvlNode<V> extends _TreeNode<V> {
   AvlNode<V> _parent;
   int _balanceFactor = 0;
 
+  @override
   AvlNode<V> get left => _left;
+
+  @override
   AvlNode<V> get right => _right;
+
+  @override
   AvlNode<V> get parent => _parent;
+
   int get balance => _balanceFactor;
 
   AvlNode({V object}) : super(object: object);
 
+  @override
   String toString() =>
       "(b:$balance o: $object l:${left != null} r:${right != null})";
 }

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -109,11 +109,14 @@ class Optional<T> extends IterableBase<T> {
       isPresent ? <T>[_value].iterator : new Iterable<T>.empty().iterator;
 
   /// Delegates to the underlying [value] hashCode.
+  @override
   int get hashCode => _value.hashCode;
 
   /// Delegates to the underlying [value] operator==.
+  @override
   bool operator ==(o) => o is Optional<T> && o._value == _value;
 
+  @override
   String toString() {
     return _value == null
         ? 'Optional { absent }'

--- a/lib/src/iterables/count.dart
+++ b/lib/src/iterables/count.dart
@@ -23,6 +23,7 @@ class _Count extends InfiniteIterable<num> {
 
   _Count(num this.start, num this.step);
 
+  @override
   Iterator<num> get iterator => new _CountIterator(start, step);
 
   // TODO(justin): return an infinite list for toList() and a special Set
@@ -35,8 +36,10 @@ class _CountIterator implements Iterator<num> {
 
   _CountIterator(num this._start, this._step);
 
+  @override
   num get current => _current;
 
+  @override
   bool moveNext() {
     _current = (_current == null) ? _start : _current + _step;
     return true;

--- a/lib/src/iterables/cycle.dart
+++ b/lib/src/iterables/cycle.dart
@@ -23,10 +23,13 @@ class _Cycle<T> extends InfiniteIterable<T> {
 
   _Cycle(this._iterable);
 
+  @override
   Iterator<T> get iterator => new _CycleIterator(_iterable);
 
+  @override
   bool get isEmpty => _iterable.isEmpty;
 
+  @override
   bool get isNotEmpty => _iterable.isNotEmpty;
 
   // TODO(justin): add methods that can be answered by the wrapped iterable
@@ -40,8 +43,10 @@ class _CycleIterator<T> implements Iterator<T> {
       : _iterable = _iterable,
         _iterator = _iterable.iterator;
 
+  @override
   T get current => _iterator.current;
 
+  @override
   bool moveNext() {
     if (!_iterator.moveNext()) {
       _iterator = _iterable.iterator;

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -25,9 +25,14 @@ class IndexedValue<V> {
 
   IndexedValue(this.index, this.value);
 
+  @override
   bool operator ==(o) =>
       o is IndexedValue && o.index == index && o.value == value;
+
+  @override
   int get hashCode => index * 31 + value.hashCode;
+
+  @override
   String toString() => '($index, $value)';
 }
 
@@ -39,17 +44,28 @@ class EnumerateIterable<V> extends IterableBase<IndexedValue<V>> {
 
   EnumerateIterable(this._iterable);
 
+  @override
   Iterator<IndexedValue<V>> get iterator =>
       new EnumerateIterator<V>(_iterable.iterator);
 
   // Length related functions are independent of the mapping.
+  @override
   int get length => _iterable.length;
+
+  @override
   bool get isEmpty => _iterable.isEmpty;
 
   // Index based lookup can be done before transforming.
+  @override
   IndexedValue<V> get first => new IndexedValue<V>(0, _iterable.first);
+
+  @override
   IndexedValue<V> get last => new IndexedValue<V>(length - 1, _iterable.last);
+
+  @override
   IndexedValue<V> get single => new IndexedValue<V>(0, _iterable.single);
+
+  @override
   IndexedValue<V> elementAt(int index) =>
       new IndexedValue<V>(index, _iterable.elementAt(index));
 }
@@ -62,8 +78,10 @@ class EnumerateIterator<V> extends Iterator<IndexedValue<V>> {
 
   EnumerateIterator(this._iterator);
 
+  @override
   IndexedValue<V> get current => _current;
 
+  @override
   bool moveNext() {
     if (_iterator.moveNext()) {
       _current = new IndexedValue(_index++, _iterator.current);

--- a/lib/src/iterables/infinite_iterable.dart
+++ b/lib/src/iterables/infinite_iterable.dart
@@ -18,35 +18,49 @@ part of quiver.iterables;
 /// [UnsupportedError] for methods that would require the Iterable to
 /// terminate.
 abstract class InfiniteIterable<T> extends IterableBase<T> {
+  @override
   bool get isEmpty => false;
 
+  @override
   bool get isNotEmpty => true;
 
+  @override
   T get last => throw new UnsupportedError('last');
 
+  @override
   int get length => throw new UnsupportedError('length');
 
+  @override
   T get single => throw new StateError('single');
 
+  @override
   bool every(bool f(T element)) => throw new UnsupportedError('every');
 
+  @override
   T1 fold<T1>(T1 initialValue, T1 combine(T1 previousValue, T element)) =>
       throw new UnsupportedError('fold');
 
+  @override
   void forEach(void f(T element)) => throw new UnsupportedError('forEach');
 
+  @override
   String join([String separator = '']) => throw new UnsupportedError('join');
 
+  @override
   T lastWhere(bool test(T value), {T orElse()}) =>
       throw new UnsupportedError('lastWhere');
 
+  @override
   T reduce(T combine(T value, T element)) =>
       throw new UnsupportedError('reduce');
 
+  @override
   T singleWhere(bool test(T value), {T orElse()}) =>
       throw new UnsupportedError('singleWhere');
 
+  @override
   List<T> toList({bool growable: true}) => throw new UnsupportedError('toList');
 
+  @override
   Set<T> toSet() => throw new UnsupportedError('toSet');
 }

--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -36,9 +36,11 @@ class _Merge<T> extends IterableBase<T> {
 
   _Merge(this._iterables, this._compare);
 
+  @override
   Iterator<T> get iterator => new _MergeIterator<T>(
       _iterables.map((i) => i.iterator).toList(growable: false), _compare);
 
+  @override
   String toString() => this.toList().toString();
 }
 
@@ -66,6 +68,7 @@ class _MergeIterator<T> implements Iterator<T> {
   _MergeIterator(List<Iterator<T>> iterators, this._compare)
       : _peekers = iterators.map((i) => new _IteratorPeeker(i)).toList();
 
+  @override
   bool moveNext() {
     // Pick the peeker that's peeking at the puniest piece
     _IteratorPeeker<T> minIter = null;
@@ -85,5 +88,6 @@ class _MergeIterator<T> implements Iterator<T> {
     return true;
   }
 
+  @override
   T get current => _current;
 }

--- a/lib/src/iterables/partition.dart
+++ b/lib/src/iterables/partition.dart
@@ -27,6 +27,7 @@ class _Partition<T> extends IterableBase<List<T>> {
     if (_size <= 0) throw new ArgumentError(_size);
   }
 
+  @override
   Iterator<List<T>> get iterator =>
       new _PartitionIterator<T>(_iterable.iterator, _size);
 }

--- a/lib/src/pattern/glob.dart
+++ b/lib/src/pattern/glob.dart
@@ -33,18 +33,23 @@ class Glob implements Pattern {
       : pattern = pattern,
         regex = _regexpFromGlobPattern(pattern);
 
+  @override
   Iterable<Match> allMatches(String str, [int start = 0]) =>
       regex.allMatches(str, start);
 
+  @override
   Match matchAsPrefix(String string, [int start = 0]) =>
       regex.matchAsPrefix(string, start);
 
   bool hasMatch(String str) => regex.hasMatch(str);
 
+  @override
   String toString() => pattern;
 
+  @override
   int get hashCode => pattern.hashCode;
 
+  @override
   bool operator ==(other) => other is Glob && pattern == other.pattern;
 }
 

--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -295,14 +295,15 @@ class _FakeTimer implements Timer {
     _nextCall = _time._elapsed + _duration;
   }
 
+  @override
   bool get isActive => _time._hasTimer(this);
 
+  @override
   void cancel() => _time._cancelTimer(this);
 
   @override
-  // TODO: Dart 2.0 requires this method to be implemented.
-  // ignore: override_on_non_overriding_getter
   int get tick {
+    // TODO: Dart 2.0 requires this method to be implemented.
     throw new UnimplementedError("tick");
   }
 

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -71,6 +71,7 @@ class _EqualityGroupMatcher extends Matcher {
     }
   }
 
+  @override
   Description describeMismatch(item, Description mismatchDescription,
           Map matchState, bool verbose) =>
       mismatchDescription.add(" ${matchState[failureReason]}");
@@ -208,5 +209,6 @@ class MatchError extends Error {
   /// The [message] describes the match error.
   MatchError([this.message]);
 
+  @override
   String toString() => message;
 }

--- a/lib/testing/src/time/time.dart
+++ b/lib/testing/src/time/time.dart
@@ -21,15 +21,18 @@ typedef int Now();
 /// via a user-supplied function.
 class FakeStopwatch implements Stopwatch {
   Now _now;
-  int frequency;
   int _start;
   int _stop;
+
+  @override
+  int frequency;
 
   FakeStopwatch(int now(), int this.frequency)
       : _now = now,
         _start = null,
         _stop = null;
 
+  @override
   void start() {
     if (isRunning) return;
     if (_start == null) {
@@ -40,11 +43,13 @@ class FakeStopwatch implements Stopwatch {
     }
   }
 
+  @override
   void stop() {
     if (!isRunning) return;
     _stop = _now();
   }
 
+  @override
   void reset() {
     if (_start == null) return;
     _start = _now();
@@ -53,6 +58,7 @@ class FakeStopwatch implements Stopwatch {
     }
   }
 
+  @override
   int get elapsedTicks {
     if (_start == null) {
       return 0;
@@ -60,11 +66,15 @@ class FakeStopwatch implements Stopwatch {
     return (_stop == null) ? (_now() - _start) : (_stop - _start);
   }
 
+  @override
   Duration get elapsed => new Duration(microseconds: elapsedMicroseconds);
 
+  @override
   int get elapsedMicroseconds => (elapsedTicks * 1000000) ~/ frequency;
 
+  @override
   int get elapsedMilliseconds => (elapsedTicks * 1000) ~/ frequency;
 
+  @override
   bool get isRunning => _start != null && _stop == null;
 }

--- a/test/collection/delegates/iterable_test.dart
+++ b/test/collection/delegates/iterable_test.dart
@@ -22,6 +22,7 @@ class MyIterable extends DelegatingIterable<String> {
 
   MyIterable(this._delegate);
 
+  @override
   Iterable<String> get delegate => _delegate;
 }
 

--- a/test/collection/delegates/list_test.dart
+++ b/test/collection/delegates/list_test.dart
@@ -22,6 +22,7 @@ class MyList extends DelegatingList<String> {
 
   MyList(this._delegate);
 
+  @override
   List<String> get delegate => _delegate;
 }
 

--- a/test/collection/delegates/map_test.dart
+++ b/test/collection/delegates/map_test.dart
@@ -22,6 +22,7 @@ class MyMap extends DelegatingMap<String, int> {
 
   MyMap(this._delegate);
 
+  @override
   Map<String, int> get delegate => _delegate;
 }
 

--- a/test/collection/delegates/queue_test.dart
+++ b/test/collection/delegates/queue_test.dart
@@ -24,6 +24,7 @@ class MyQueue extends DelegatingQueue<String> {
 
   MyQueue(this._delegate);
 
+  @override
   Queue<String> get delegate => _delegate;
 }
 

--- a/test/collection/delegates/set_test.dart
+++ b/test/collection/delegates/set_test.dart
@@ -24,6 +24,7 @@ class MySet extends DelegatingSet<String> {
 
   MySet(this._delegate);
 
+  @override
   Set<String> get delegate => _delegate;
 }
 

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -1020,10 +1020,13 @@ class Pair {
   final x;
   final y;
   Pair(this.x, this.y);
+
+  @override
   bool operator ==(other) {
     if (x != other.x) return false;
     return equals(y).matches(other.y, {});
   }
 
+  @override
   String toString() => "($x, $y)";
 }

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -16,14 +16,17 @@ import 'package:quiver/iterables.dart';
 import 'package:test/test.dart';
 
 class NaturalNumberIterable extends InfiniteIterable<int> {
+  @override
   final iterator = new NaturalNumberIterator();
 }
 
 class NaturalNumberIterator implements Iterator<int> {
   int _current = -1;
 
+  @override
   int get current => _current;
 
+  @override
   bool moveNext() {
     ++_current;
     return true;

--- a/test/mirrors_test.dart
+++ b/test/mirrors_test.dart
@@ -92,6 +92,10 @@ void main() {
 
 class Foo extends IterableBase implements Comparable {
   String a;
+
+  @override
   Iterator get iterator => null;
+
+  @override
   int compareTo(o) => 0;
 }


### PR DESCRIPTION
Also enables the annotate_overrides lint, and eliminates all instances
where that lint was marked as ignored. Further, removes all instances of
the (unimplemented) `retype` method on collection classes, as it was
dropped before Dart 2.0 was finalized.