### PR TITLE
Eliminate function literals in forEach calls

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -33,7 +33,7 @@ linter:
     # - avoid_double_and_int_checks # only useful when targeting JS runtime
     - avoid_empty_else
     - avoid_field_initializers_in_const_classes
-    # ENABLE - avoid_function_literals_in_foreach_calls
+    - avoid_function_literals_in_foreach_calls
     # - avoid_implementing_value_types # not yet tested
     # ENABLE - avoid_init_to_null
     # - avoid_js_rounded_ints # only useful when targeting JS runtime

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -80,8 +80,11 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
   void addAll(Map<K, V> other) => other.forEach((k, v) => this[k] = v);
 
   @override
-  void addEntries(Iterable<MapEntry<K, V>> entries) =>
-      entries.forEach((entry) => this[entry.key] = entry.value);
+  void addEntries(Iterable<MapEntry<K, V>> entries) {
+    for (final entry in entries) {
+      this[entry.key] = entry.value;
+    }
+  }
 
   @override
   LinkedLruHashMap<K2, V2> cast<K2, V2>() {

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -197,7 +197,9 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
   @override
   void forEach(void f(K key, V value)) {
     _map.forEach((K key, Iterable<V> values) {
-      values.forEach((V value) => f(key, value));
+      for (final V value in values) {
+        f(key, value);
+      }
     });
   }
 

--- a/test/collection/delegates/iterable_test.dart
+++ b/test/collection/delegates/iterable_test.dart
@@ -74,7 +74,7 @@ void main() {
 
     test('forEach', () {
       final s = new StringBuffer();
-      delegatingIterable.forEach((e) => s.write(e));
+      delegatingIterable.forEach(s.write);
       expect(s.toString(), equals('abcc'));
     });
 

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -117,8 +117,9 @@ void main() {
 
       expect(lruMap.keys.toList(), ['C', 'B', 'A']);
 
-      lruMap.keys.forEach((_) {});
-      lruMap.keys.forEach((_) {});
+      void nop(String key) {}
+      lruMap.keys.forEach(nop);
+      lruMap.keys.forEach(nop);
 
       expect(lruMap.keys.toList(), ['C', 'B', 'A']);
     });
@@ -129,8 +130,9 @@ void main() {
 
       expect(lruMap.values.toList(), ['Charlie', 'Beta', 'Alpha']);
 
-      lruMap.values.forEach((_) {});
-      lruMap.values.forEach((_) {});
+      void nop(String key) {}
+      lruMap.values.forEach(nop);
+      lruMap.values.forEach(nop);
 
       expect(lruMap.values.toList(), ['Charlie', 'Beta', 'Alpha']);
     });

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -62,7 +62,8 @@ void main() {
     });
 
     test('every should throw UnsupportedError', () {
-      expect(() => it.every((_) => true), throwsUnsupportedError);
+      bool yes(int x) => true;
+      expect(() => it.every(yes), throwsUnsupportedError);
     });
 
     test('fold should throw UnsupportedError', () {
@@ -70,7 +71,8 @@ void main() {
     });
 
     test('forEach should throw UnsupportedError', () {
-      expect(() => it.forEach((_) {}), throwsUnsupportedError);
+      void nop(int x) {}
+      expect(() => it.forEach(nop), throwsUnsupportedError);
     });
 
     test('join should throw UnsupportedError', () {

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -61,8 +61,9 @@ void main() {
     test("should throw on null elements", () {
       var a = ['a', null, 'c'];
       var b = ['a', 'b', 'c'];
-      expect(() => merge([a, b]).forEach((e) {}), throwsNoSuchMethodError);
-      expect(() => merge([b, a]).forEach((e) {}), throwsNoSuchMethodError);
+      void nop(String s) {}
+      expect(() => merge([a, b]).forEach(nop), throwsNoSuchMethodError);
+      expect(() => merge([b, a]).forEach(nop), throwsNoSuchMethodError);
     }, tags: ['fails-on-dartdevc', 'fails-on-dart2js']);
 
     test("should handle zig-zag case", () {


### PR DESCRIPTION
Enables the avoid_function_literals_in_foreach_calls lint.