### PR TITLE
Avoid renaming overridden method parameters

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -41,7 +41,7 @@ linter:
     # - avoid_positional_boolean_parameters # not yet tested
     # - avoid_private_typedef_functions # we prefer having typedef (discussion in https://github.com/flutter/flutter/pull/16356)
     - avoid_relative_lib_imports
-    # ENABLE - avoid_renaming_method_parameters
+    - avoid_renaming_method_parameters
     # ENABLE - avoid_return_types_on_setters
     # - avoid_returning_null # there are plenty of valid reasons to return null
     # - avoid_returning_null_for_future # not yet tested

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -67,16 +67,18 @@ class Method /* implements Function */ {
   Method(this.mirror, this.symbol);
 
   @override
-  dynamic noSuchMethod(Invocation i) {
-    if (i.isMethod && i.memberName == const Symbol('call')) {
-      if (i.namedArguments != null && i.namedArguments.isNotEmpty) {
+  dynamic noSuchMethod(Invocation invocation) {
+    if (invocation.isMethod && invocation.memberName == const Symbol('call')) {
+      if (invocation.namedArguments != null &&
+          invocation.namedArguments.isNotEmpty) {
         // this will fail until named argument support is implemented
         return mirror
-            .invoke(symbol, i.positionalArguments, i.namedArguments)
+            .invoke(symbol, invocation.positionalArguments,
+                invocation.namedArguments)
             .reflectee;
       }
-      return mirror.invoke(symbol, i.positionalArguments).reflectee;
+      return mirror.invoke(symbol, invocation.positionalArguments).reflectee;
     }
-    return super.noSuchMethod(i);
+    return super.noSuchMethod(invocation);
   }
 }

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -26,8 +26,8 @@ class IndexedValue<V> {
   IndexedValue(this.index, this.value);
 
   @override
-  bool operator ==(o) =>
-      o is IndexedValue && o.index == index && o.value == value;
+  bool operator ==(other) =>
+      other is IndexedValue && other.index == index && other.value == value;
 
   @override
   int get hashCode => index * 31 + value.hashCode;

--- a/lib/src/iterables/infinite_iterable.dart
+++ b/lib/src/iterables/infinite_iterable.dart
@@ -34,7 +34,7 @@ abstract class InfiniteIterable<T> extends IterableBase<T> {
   T get single => throw new StateError('single');
 
   @override
-  bool every(bool f(T element)) => throw new UnsupportedError('every');
+  bool every(bool test(T element)) => throw new UnsupportedError('every');
 
   @override
   T1 fold<T1>(T1 initialValue, T1 combine(T1 previousValue, T element)) =>


### PR DESCRIPTION
Fixes any cases where method parameters of overridden methods weren't
named consistently with their superclass declaration. 

Enables the avoid_renaming_method_parameters lint.