### PR TITLE
Make empty while blocks explicit

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -68,7 +68,7 @@ linter:
     # ENABLE - directives_ordering
     - empty_catches
     - empty_constructor_bodies
-    # ENABLE - empty_statements
+    - empty_statements
     # - file_names # not yet tested
     # ENABLE - flutter_style_todos
     # ENABLE - hash_and_equals

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -90,12 +90,12 @@ void main() {
 
       test("works bidirectionally", () {
         var it = tree.iterator;
-        while (it.moveNext());
+        while (it.moveNext()) {}
         expect(it.movePrevious(), isTrue,
             reason: "we can backup after walking the entire list");
         expect(it.current, equals(30),
             reason: "the last element is what we expect");
-        while (it.movePrevious());
+        while (it.movePrevious()) {}
         expect(it.moveNext(), isTrue,
             reason: "we can move next after walking to the front of the set");
         expect(it.current, equals(10),


### PR DESCRIPTION
In the test for TreeSet, we call Iterator.moveNext and
Iterator.movePrevious to cycle through to the end/beginning of the list.
Make the while blocks explicit for readability.

Enables the empty_statements lint.