### PR TITLE
Add missing hashCode override in test class

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -71,7 +71,7 @@ linter:
     - empty_statements
     # - file_names # not yet tested
     # ENABLE - flutter_style_todos
-    # ENABLE - hash_and_equals
+    - hash_and_equals
     - implementation_imports
     # - invariant_booleans # too many false positives: https://github.com/dart-lang/linter/issues/811
     - iterable_contains_unrelated_type

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -1019,13 +1019,16 @@ void main() {
 class Pair {
   final x;
   final y;
-  Pair(this.x, this.y);
+  Pair(this.x, this.y) : assert(x != null && y != null);
 
   @override
   bool operator ==(other) {
     if (x != other.x) return false;
     return equals(y).matches(other.y, {});
   }
+
+  @override
+  int get hashCode => x.hashCode ^ y.hashCode;
 
   @override
   String toString() => "($x, $y)";


### PR DESCRIPTION
Adds a hashCode override to a Pair class used in the unit tests for
Multimap. This implemented operator== but failed to implement hashCode.

Enables the hash_and_equals lint.