### PR TITLE
Fix inconsistently named identifiers

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -83,7 +83,7 @@ linter:
     # - literal_only_boolean_expressions # too many false positives: https://github.com/dart-lang/sdk/issues/34181
     - no_adjacent_strings_in_list
     - no_duplicate_case_values
-    # ENABLE - non_constant_identifier_names
+    - non_constant_identifier_names
     # - null_closures  # not yet tested
     # - omit_local_variable_types # opposite of always_specify_types
     # - one_member_abstracts # too many false positives

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -48,7 +48,7 @@ part of quiver.async;
 ///     2014-05-04 20:06:00.423
 ///     ...
 class Metronome extends Stream<DateTime> {
-  static final DateTime _EPOCH = new DateTime.fromMillisecondsSinceEpoch(0);
+  static final DateTime _epoch = new DateTime.fromMillisecondsSinceEpoch(0);
 
   final Clock clock;
   final Duration interval;
@@ -63,7 +63,7 @@ class Metronome extends Stream<DateTime> {
   bool get isBroadcast => true;
 
   Metronome.epoch(Duration interval, {Clock clock: const Clock()})
-      : this._(interval, clock: clock, anchor: _EPOCH);
+      : this._(interval, clock: clock, anchor: _epoch);
 
   Metronome.periodic(Duration interval,
       {Clock clock: const Clock(), DateTime anchor})

--- a/lib/src/iterables/range.dart
+++ b/lib/src/iterables/range.dart
@@ -16,18 +16,17 @@ part of quiver.iterables;
 
 /// Returns an [Iterable] sequence of [num]s.
 ///
-/// If only one argument is provided, [start_or_stop] is the upper bound for
-/// the sequence. If two or more arguments are provided, [stop] is the upper
-/// bound.
+/// If only one argument is provided, [startOrStop] is the upper bound for the
+/// sequence. If two or more arguments are provided, [stop] is the upper bound.
 ///
-/// The sequence starts at 0 if one argument is provided, or [start_or_stop] if
+/// The sequence starts at 0 if one argument is provided, or [startOrStop] if
 /// two or more arguments are provided. The sequence increments by 1, or [step]
 /// if provided. [step] can be negative, in which case the sequence counts down
 /// from the starting point and [stop] must be less than the starting point so
 /// that it becomes the lower bound.
-Iterable<num> range(num start_or_stop, [num stop, num step]) sync* {
-  final start = stop == null ? 0 : start_or_stop;
-  stop ??= start_or_stop;
+Iterable<num> range(num startOrStop, [num stop, num step]) sync* {
+  final start = stop == null ? 0 : startOrStop;
+  stop ??= startOrStop;
   step ??= 1;
 
   if (step == 0) throw new ArgumentError('step cannot be 0');


### PR DESCRIPTION
Renames _EPOCH to _epoch and start_or_stop to startOrStop. Also enables
the non_constant_identifier_names lint.