### PR TITLE
Use List/Map literals where possible

### DIFF
--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -229,7 +229,7 @@ class ListMultimap<K, V> extends _BaseMultimap<K, V, List<V>> {
       : super.fromIterable(iterable, key: key, value: value);
 
   @override
-  List<V> _create() => new List<V>();
+  List<V> _create() => [];
   @override
   void _add(List<V> iterable, V value) {
     iterable.add(value);

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -555,7 +555,7 @@ void main() {
     });
 
     test('should support iteration over all {key, Iterable<value>} pairs', () {
-      Map map = new Map();
+      Map map = {};
       var mmap = new ListMultimap<String, String>()
         ..add('k1', 'v1')
         ..add('k1', 'v2')
@@ -991,7 +991,7 @@ void main() {
     });
 
     test('should support iteration over all {key, Iterable<value>} pairs', () {
-      Map map = new Map();
+      Map map = {};
       var mmap = new SetMultimap<String, String>()
         ..add('k1', 'v1')
         ..add('k1', 'v2')


### PR DESCRIPTION
This does not yet enable the prefer_collection_literals lint since that
enforces the use of Set literals, which weren't introduced until Dart
2.2, and Quiver supports back to Dart 2.0.