### PR TITLE
Use const constructors where possible

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -98,7 +98,7 @@ linter:
     # - prefer_asserts_with_message # not yet tested
     # ENABLE - prefer_collection_literals
     - prefer_conditional_assignment
-    # ENABLE - prefer_const_constructors
+    - prefer_const_constructors
     - prefer_const_constructors_in_immutables
     # ENABLE - prefer_const_declarations
     - prefer_const_literals_to_create_immutables

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -89,7 +89,7 @@ class Optional<T> extends IterableBase<T> {
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
   Optional<S> transform<S>(S transformer(T value)) {
     return _value == null
-        ? new Optional.absent()
+        ? const Optional.absent()
         : new Optional.of(transformer(_value));
   }
 
@@ -100,7 +100,7 @@ class Optional<T> extends IterableBase<T> {
   /// Returns [absent()] if the transformer returns [null].
   Optional<S> transformNullable<S>(S transformer(T value)) {
     return _value == null
-        ? new Optional.absent()
+        ? const Optional.absent()
         : new Optional.fromNullable(transformer(_value));
   }
 

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -205,7 +205,7 @@ void main() {
       lruMap = new LruMap()
         ..addAll({'A': 'Alpha', 'B': 'Beta', 'C': 'Charlie'});
 
-      var entries = [new MapEntry('D', 'Delta'), new MapEntry('E', 'Echo')];
+      var entries = [const MapEntry('D', 'Delta'), const MapEntry('E', 'Echo')];
       lruMap.addEntries(entries);
       expect(lruMap.keys.toList(), ['E', 'D', 'C', 'B', 'A']);
     });
@@ -214,7 +214,7 @@ void main() {
       lruMap = new LruMap()
         ..addAll({'A': 'Alpha', 'B': 'Beta', 'C': 'Charlie'});
 
-      var entries = [new MapEntry('B', 'Bravo'), new MapEntry('E', 'Echo')];
+      var entries = [const MapEntry('B', 'Bravo'), const MapEntry('E', 'Echo')];
       lruMap.addEntries(entries);
       expect(lruMap.keys.toList(), ['E', 'B', 'C', 'A']);
     });

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -20,7 +20,7 @@ import 'package:test/test.dart';
 void main() {
   group('Optional', () {
     test('absent should be not present and not gettable', () {
-      Optional absent = new Optional<int>.absent();
+      const Optional absent = const Optional<int>.absent();
       expect(absent.isPresent, isFalse);
       expect(absent.isNotPresent, isTrue);
       expect(() => absent.value, throwsStateError);
@@ -39,7 +39,7 @@ void main() {
         value = v;
       });
       expect(value, 7);
-      new Optional<int>.absent().ifPresent((v) {
+      const Optional<int>.absent().ifPresent((v) {
         value = v;
       });
       expect(value, 7);
@@ -51,33 +51,33 @@ void main() {
         value = 7;
       });
       expect(value, null);
-      new Optional<int>.absent().ifAbsent(() {
+      const Optional<int>.absent().ifAbsent(() {
         value = 7;
       });
       expect(value, 7);
     });
 
     test('fromNullable should allow present or absent', () {
-      expect(new Optional<int>.fromNullable(7).value, 7);
-      expect(new Optional<int>.fromNullable(null).isPresent, isFalse);
-      expect(new Optional<int>.fromNullable(null).isNotPresent, isTrue);
+      expect(const Optional<int>.fromNullable(7).value, 7);
+      expect(const Optional<int>.fromNullable(null).isPresent, isFalse);
+      expect(const Optional<int>.fromNullable(null).isNotPresent, isTrue);
     });
 
     test('or should return present and replace absent', () {
-      expect(new Optional<int>.fromNullable(7).or(13), 7);
-      expect(new Optional<int>.fromNullable(null).or(13), 13);
+      expect(const Optional<int>.fromNullable(7).or(13), 7);
+      expect(const Optional<int>.fromNullable(null).or(13), 13);
     });
 
     test('orNull should return value if present or null if absent', () {
-      expect(new Optional<int>.fromNullable(7).orNull, isNotNull);
-      expect(new Optional<int>.fromNullable(null).orNull, isNull);
+      expect(const Optional<int>.fromNullable(7).orNull, isNotNull);
+      expect(const Optional<int>.fromNullable(null).orNull, isNull);
     });
 
     test('transform should return transformed value or absent', () {
-      expect(new Optional<int>.fromNullable(7).transform((a) => a + 1),
+      expect(const Optional<int>.fromNullable(7).transform((a) => a + 1),
           equals(new Optional<int>.of(8)));
       expect(
-          new Optional<int>.fromNullable(null)
+          const Optional<int>.fromNullable(null)
               .transform((a) => a + 1)
               .isPresent,
           isFalse);
@@ -85,15 +85,16 @@ void main() {
 
     test('transform should throw ArgumentError if transformed value is null',
         () {
-      expect(() => new Optional<int>.fromNullable(7).transform((_) => null),
+      expect(() => const Optional<int>.fromNullable(7).transform((_) => null),
           throwsArgumentError);
     });
 
     test('transformNullable should return transformed value or absent', () {
-      expect(new Optional<int>.fromNullable(7).transformNullable((a) => a + 1),
+      expect(
+          const Optional<int>.fromNullable(7).transformNullable((a) => a + 1),
           equals(new Optional<int>.of(8)));
       expect(
-          new Optional<int>.fromNullable(null)
+          const Optional<int>.fromNullable(null)
               .transformNullable((a) => a + 1)
               .isPresent,
           isFalse);
@@ -102,7 +103,7 @@ void main() {
     test('transformNullable should return absent if transformed value is null',
         () {
       expect(
-          new Optional<int>.fromNullable(7)
+          const Optional<int>.fromNullable(7)
               .transformNullable((_) => null)
               .isPresent,
           isFalse);
@@ -113,12 +114,12 @@ void main() {
           new Set.from([
             new Optional<int>.of(7),
             new Optional<int>.of(8),
-            new Optional<int>.absent()
+            const Optional<int>.absent()
           ]),
           equals(new Set.from([
             new Optional<int>.of(7),
             new Optional<int>.of(8),
-            new Optional<int>.absent()
+            const Optional<int>.absent()
           ])));
       expect(
           new Set.from([new Optional<int>.of(7), new Optional<int>.of(8)]),
@@ -128,13 +129,13 @@ void main() {
 
     test('== should compare by value', () {
       expect(new Optional<int>.of(7), equals(new Optional<int>.of(7)));
-      expect(new Optional<int>.fromNullable(null),
-          equals(new Optional<int>.fromNullable(null)));
+      expect(const Optional<int>.fromNullable(null),
+          equals(const Optional<int>.fromNullable(null)));
       expect(
-          new Optional<int>.fromNullable(null) ==
-              new Optional<String>.fromNullable(null),
+          const Optional<int>.fromNullable(null) ==
+              const Optional<String>.fromNullable(null),
           isFalse);
-      expect(new Optional<int>.fromNullable(null),
+      expect(const Optional<int>.fromNullable(null),
           isNot(equals(new Optional<int>.of(7))));
       expect(new Optional<int>.of(7), isNot(equals(new Optional<int>.of(8))));
     });
@@ -142,7 +143,7 @@ void main() {
     test('toString should show the value or absent', () {
       expect(
           new Optional<int>.of(7).toString(), equals('Optional { value: 7 }'));
-      expect(new Optional<int>.fromNullable(null).toString(),
+      expect(const Optional<int>.fromNullable(null).toString(),
           equals('Optional { absent }'));
     });
 

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -464,10 +464,10 @@ void main() {
           'if scheduled first', () {
         new FakeAsync().run((async) {
           final log = [];
-          new Timer.periodic(new Duration(seconds: 1), (_) {
+          new Timer.periodic(const Duration(seconds: 1), (_) {
             log.add('periodic');
           });
-          new Future.delayed(new Duration(seconds: 2), () {
+          new Future.delayed(const Duration(seconds: 2), () {
             log.add('delayed');
           });
           expect(log, hasLength(0), reason: 'should not flush until asked to');

--- a/test/time/clock_test.dart
+++ b/test/time/clock_test.dart
@@ -41,7 +41,10 @@ void main() {
       // At 10ms the test doesn't seem to be flaky.
       var epsilon = 10;
       expect(
-          new DateTime.now().difference(new Clock().now()).inMilliseconds.abs(),
+          new DateTime.now()
+              .difference(const Clock().now())
+              .inMilliseconds
+              .abs(),
           lessThan(epsilon));
       expect(
           new DateTime.now()


### PR DESCRIPTION
Enables the prefer_const_constructors lint.