### PR TITLE
Declare a top-level final as const in a test

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -100,7 +100,7 @@ linter:
     # ENABLE - prefer_conditional_assignment
     # ENABLE - prefer_const_constructors
     - prefer_const_constructors_in_immutables
-    # ENABLE - prefer_const_declarations
+    - prefer_const_declarations
     - prefer_const_literals_to_create_immutables
     # - prefer_constructors_over_static_methods # not yet tested
     - prefer_contains

--- a/test/pattern/pattern_test.dart
+++ b/test/pattern/pattern_test.dart
@@ -17,7 +17,7 @@ library quiver.pattern_test;
 import 'package:test/test.dart';
 import 'package:quiver/pattern.dart';
 
-final _specialChars = r'\^$.|+[](){}';
+const _specialChars = r'\^$.|+[](){}';
 
 void main() {
   group('escapeRegex', () {


### PR DESCRIPTION
The _specialChars string used in the escapeRegex test had been declared
final but is now const. Also enables the prefer_const_declarations lint.