### PR TITLE
Use null-default operator where possible

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -115,7 +115,7 @@ linter:
     # - prefer_function_declarations_over_variables # not yet tested
     # ENABLE - prefer_generic_function_type_aliases
     - prefer_if_elements_to_conditional_expressions
-    # ENABLE - prefer_if_null_operators
+    - prefer_if_null_operators
     # ENABLE - prefer_initializing_formals
     - prefer_inlined_adds
     # - prefer_int_literals # not yet tested

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -40,7 +40,7 @@ class CountdownTimer extends Stream<CountdownTimer> {
   CountdownTimer(Duration duration, Duration increment, {Stopwatch stopwatch})
       : _duration = duration,
         increment = increment,
-        _stopwatch = stopwatch == null ? new Stopwatch() : stopwatch,
+        _stopwatch = stopwatch ?? new Stopwatch(),
         _controller =
             new StreamController<CountdownTimer>.broadcast(sync: true) {
     _timer = new Timer.periodic(increment, _tick);

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -74,8 +74,7 @@ class Metronome extends Stream<DateTime> {
         this.anchor = anchor,
         this.interval = interval,
         this._intervalMs = interval.inMilliseconds,
-        this._anchorMs =
-            (anchor == null ? clock.now() : anchor).millisecondsSinceEpoch {
+        this._anchorMs = (anchor ?? clock.now()).millisecondsSinceEpoch {
     _controller = new StreamController<DateTime>.broadcast(
         sync: true,
         onCancel: () {

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -131,7 +131,7 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
 
   @override
   Future addStream(Stream<List<T>> stream) {
-    var lastStream = _currentStream == null ? stream : _currentStream;
+    var lastStream = _currentStream ?? stream;
     if (_sub != null) {
       _sub.cancel();
     }

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -22,7 +22,7 @@ class MapCache<K, V> implements Cache<K, V> {
   final _outstanding = <K, FutureOr<V>>{};
 
   /// Creates a new [MapCache], optionally using [map] as the backing [Map].
-  MapCache({Map<K, V> map}) : _map = map != null ? map : new HashMap<K, V>();
+  MapCache({Map<K, V> map}) : _map = map ?? new HashMap<K, V>();
 
   /// Creates a new [MapCache], using [LruMap] as the backing [Map].
   /// Optionally specify [maximumSize].

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -76,7 +76,7 @@ class Optional<T> extends IterableBase<T> {
     if (defaultValue == null) {
       throw new ArgumentError('defaultValue must not be null.');
     }
-    return _value == null ? defaultValue : _value;
+    return _value ?? defaultValue;
   }
 
   /// Gets the Optional value, or [null] if there is none.

--- a/test/check_test.dart
+++ b/test/check_test.dart
@@ -184,9 +184,8 @@ void main() {
           expect(e, isRangeError);
           expect(
               e.message,
-              expectedMessage == null
-                  ? 'index $index not valid for list of size $size'
-                  : expectedMessage);
+              expectedMessage ??
+                  'index $index not valid for list of size $size');
         }
       }
 


### PR DESCRIPTION
Replace explicit if-null/conditional checks with use of the ?? operator
where possible.

Enables the prefer_if_null_operators lint.