### PR TITLE
Use /// for doc comments

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -132,7 +132,7 @@ linter:
     # - provide_deprecation_message # not yet tested
     # - public_member_api_docs # enabled on a case-by-case basis; see e.g. packages/analysis_options.yaml
     - recursive_getters
-    # ENABLE - slash_for_doc_comments
+    - slash_for_doc_comments
     # - sort_child_properties_last # not yet tested
     # ENABLE - sort_constructors_first
     - sort_pub_dependencies

--- a/lib/pattern.dart
+++ b/lib/pattern.dart
@@ -68,10 +68,8 @@ class _MultiPattern extends Pattern {
   }
 }
 
-/**
- * Returns true if [pattern] has a single match in [str] that matches the whole
- * string, not a substring.
- */
+/// Returns true if [pattern] has a single match in [str] that matches the
+/// whole string, not a substring.
 bool matchesFull(Pattern pattern, String str) {
   var match = pattern.matchAsPrefix(str);
   return match != null && match.end == str.length;


### PR DESCRIPTION
Fixes one remaining use of old-style /** ... */ doc comments and enables
the slash_for_doc_comments lint.