### PR TITLE
Enable the unnecessary_overrides lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -150,7 +150,7 @@ linter:
     # ENABLE - unnecessary_new
     - unnecessary_null_aware_assignments
     - unnecessary_null_in_if_null_operators
-    # ENABLE - unnecessary_overrides
+    - unnecessary_overrides
     # ENABLE - unnecessary_parenthesis
     # ENABLE - unnecessary_statements
     # ENABLE - unnecessary_this

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -278,7 +278,7 @@ class _NonReflexiveObject {
   bool operator ==(Object o) => false;
 
   @override
-  int get hashCode => super.hashCode;
+  int get hashCode => 0;
 }
 
 /// Test class with valid equals and hashCode methods. Testers created


### PR DESCRIPTION
Required implementing hashCode on a test class to prevent the
hashcode/equals linter from complaining.