### PR TITLE
Enable the unnecessary_statements lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -152,7 +152,7 @@ linter:
     - unnecessary_null_in_if_null_operators
     - unnecessary_overrides
     - unnecessary_parenthesis
-    # ENABLE - unnecessary_statements
+    - unnecessary_statements
     # ENABLE - unnecessary_this
     - unrelated_type_equality_checks
     # - unsafe_html # not yet tested

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -36,7 +36,8 @@ void main() {
 
       expect(lruMap.keys.toList(), ['C', 'B', 'A']);
 
-      lruMap['B'];
+      // Trigger promotion of B.
+      final _ = lruMap['B'];
 
       // In a LRU cache, the first key is the one that will be removed if the
       // capacity is reached, so adding keys to the end is considered to be a
@@ -280,7 +281,9 @@ void main() {
 
       test('linkage correctly preserved on remove', () {
         lruMap.remove('B');
-        lruMap['A'];
+
+        // Order is now [C, A]. Trigger promotion of A to check linkage.
+        final _ = lruMap['A'];
 
         final keys = <String>[];
         lruMap.forEach((String k, String v) => keys.add(k));
@@ -291,9 +294,13 @@ void main() {
     test('the linked list is mutated when promoting an item in the middle', () {
       LruMap<String, int> lruMap = new LruMap(maximumSize: 3)
         ..addAll({'C': 1, 'A': 1, 'B': 1});
+      // Order is now [B, A, C]. Trigger promotion of A.
       lruMap['A'] = 1;
-      lruMap['C'];
+
+      // Order is now [A, B, C]. Trigger promotion of C to check linkage.
+      final _ = lruMap['C'];
       expect(lruMap.length, lruMap.keys.length);
+      expect(lruMap.keys.toList(), ['C', 'A', 'B']);
     });
 
     group('`putIfAbsent`', () {


### PR DESCRIPTION
There are a few cases in the LruMap unit tests where we want to test the
effect of accesses to an LruMap but don't care about the actual value.
We explicitly ignore this lint on those lines.