### PR TITLE
Enable always_require_non_null_named_parameters lint

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -21,7 +21,7 @@ linter:
     - always_declare_return_types
     # ENABLE - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
-    # ENABLE - always_require_non_null_named_parameters
+    - always_require_non_null_named_parameters
     # ENABLE - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types


### PR DESCRIPTION
This requires that for any named parameter which is asserted to be
non-null is annotated with @required from package:meta.