### PR TITLE
Eliminate classImplements TODO

### DIFF
--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -27,7 +27,6 @@ bool implements(Object o, Type type) =>
 /// represented by [interfaceMirror].
 bool classImplements(ClassMirror classMirror, ClassMirror interfaceMirror) {
   if (classMirror == null) return false;
-  // TODO: change to comparing mirrors when dartbug.com/19781 is fixed
   if (classMirror.qualifiedName == interfaceMirror.qualifiedName) return true;
   if (classImplements(classMirror.superclass, interfaceMirror)) return true;
   if (classMirror.superinterfaces


### PR DESCRIPTION
This suggested implementation cleanup when htts://dartbug.com/19781 was
fixed. The bug in question was filed on the assumption that a == b in the
following example:

    class Foo implements Comparable {}

    var a = reflect(Foo).superinterfaces
                .singleWhere((e) => e.simpleName == #Comparable);
    var b = reflectClass(Comparable)

However, in this example a is a mirror on Comparable<dynamic> (an
instantiation of a generic class declaration) whereas b is a mirror on
Comparable (a generic class declaration).