### PR TITLE
Eliminate unnecessary const keywords

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -144,7 +144,7 @@ linter:
     # - unawaited_futures # too many false positives
     # - unnecessary_await_in_return # not yet tested
     - unnecessary_brace_in_string_interps
-    # ENABLE - unnecessary_const
+    - unnecessary_const
     - unnecessary_getters_setters
     # - unnecessary_lambdas # has false positives: https://github.com/dart-lang/linter/issues/498
     # ENABLE - unnecessary_new

--- a/lib/src/time/duration_unit_constants.dart
+++ b/lib/src/time/duration_unit_constants.dart
@@ -14,10 +14,10 @@
 
 part of quiver.time;
 
-const Duration aMicrosecond = const Duration(microseconds: 1);
-const Duration aMillisecond = const Duration(milliseconds: 1);
-const Duration aSecond = const Duration(seconds: 1);
-const Duration aMinute = const Duration(minutes: 1);
-const Duration anHour = const Duration(hours: 1);
-const Duration aDay = const Duration(days: 1);
-const Duration aWeek = const Duration(days: 7);
+const Duration aMicrosecond = Duration(microseconds: 1);
+const Duration aMillisecond = Duration(milliseconds: 1);
+const Duration aSecond = Duration(seconds: 1);
+const Duration aMinute = Duration(minutes: 1);
+const Duration anHour = Duration(hours: 1);
+const Duration aDay = Duration(days: 1);
+const Duration aWeek = Duration(days: 7);

--- a/lib/src/time/util.dart
+++ b/lib/src/time/util.dart
@@ -16,7 +16,7 @@ part of quiver.time;
 
 /// Days in a month. This array uses 1-based month numbers, i.e. January is
 /// the 1-st element in the array, not the 0-th.
-const _daysInMonth = const [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+const _daysInMonth = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
 
 /// Returns the number of days in the specified month.
 ///

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -48,7 +48,7 @@ part of quiver.testing.equality;
 ///      where both equality groups and the items within equality groups are
 ///      numbered starting from 1.  When either a constructor argument or an
 ///      equal object is provided, that becomes group 1.
-const Matcher areEqualityGroups = const _EqualityGroupMatcher();
+const Matcher areEqualityGroups = _EqualityGroupMatcher();
 
 const _repetitions = 3;
 
@@ -188,7 +188,7 @@ class _EqualityGroupMatcher extends Matcher {
 }
 
 class _NotAnInstance {
-  static const equalToNothing = const _NotAnInstance._();
+  static const equalToNothing = _NotAnInstance._();
   const _NotAnInstance._();
 }
 

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -20,7 +20,7 @@ import 'package:test/test.dart';
 void main() {
   group('Optional', () {
     test('absent should be not present and not gettable', () {
-      const Optional absent = const Optional<int>.absent();
+      const Optional absent = Optional<int>.absent();
       expect(absent.isPresent, isFalse);
       expect(absent.isNotPresent, isTrue);
       expect(() => absent.value, throwsStateError);


### PR DESCRIPTION
Eliminates RHS const keywords when it can be inferred. 

Enables the unnecessary_const lint.