### PR TITLE
Use isEmpty rather than checks vs 0 where possible

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -120,7 +120,7 @@ linter:
     - prefer_inlined_adds
     # - prefer_int_literals # not yet tested
     # - prefer_interpolation_to_compose_strings # not yet tested
-    # ENABLE - prefer_is_empty
+    - prefer_is_empty
     - prefer_is_not_empty
     - prefer_iterable_whereType
     # - prefer_mixin # https://github.com/dart-lang/language/issues/32

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -22,6 +22,12 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   @override
   int get length;
 
+  @override
+  bool get isEmpty => length == 0;
+
+  @override
+  bool get isNotEmpty => length != 0;
+
   /// Create a new [TreeSet] with an ordering defined by [comparator] or the
   /// default `(a, b) => a.compareTo(b)`.
   factory TreeSet({Comparator<V> comparator}) {
@@ -887,7 +893,7 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
   _AvlTreeIterator._(this.tree,
       {this.reversed = false, this.inclusive = true, this.anchorObject})
       : this._modCountGuard = tree._modCount {
-    if (anchorObject == null || tree.length == 0) {
+    if (anchorObject == null || tree.isEmpty) {
       // If the anchor is far left or right, we're just a normal iterator.
       state = reversed ? RIGHT : LEFT;
       _moveNext = reversed ? _movePreviousNormal : _moveNextNormal;
@@ -940,7 +946,7 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
     if (_modCountGuard != tree._modCount) {
       throw new ConcurrentModificationError(tree);
     }
-    if (state == RIGHT || tree.length == 0) return false;
+    if (state == RIGHT || tree.isEmpty) return false;
     switch (state) {
       case LEFT:
         _current = tree._root.minimumNode;
@@ -960,7 +966,7 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
     if (_modCountGuard != tree._modCount) {
       throw new ConcurrentModificationError(tree);
     }
-    if (state == LEFT || tree.length == 0) return false;
+    if (state == LEFT || tree.isEmpty) return false;
     switch (state) {
       case RIGHT:
         _current = tree._root.maximumNode;

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -134,7 +134,7 @@ bool isWhitespace(int rune) =>
 /// If there are an odd number of characters to pad, then the right will be
 /// padded with one more than the left.
 String center(String input, int width, String fill) {
-  if (fill == null || fill.length == 0) {
+  if (fill == null || fill.isEmpty) {
     throw new ArgumentError('fill cannot be null or empty');
   }
   input ??= '';


### PR DESCRIPTION
This also adds TreeSet.isEmpty and TreeSet.isNotEmpty in order to fix a
stack overflow error when TreeSet.isEmpty or TreeSet.isNotEmpty are
called in the iterator's moveNext implementation.

Since TreeSet extends IterableBase, and didn't override isEmpty, it fell back
on the IterableBase implementation, which is to obtain an iterable over itself
and check the return value of calling moveNext. Since moveNext now calls
isEmpty, we drop into an infinite recurive loop. A quick length check
implementation is a significant performance improvement as well.

Enables the prefer_is_empty lint.