### PR TITLE
Eliminate types on initializing formals

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -140,7 +140,7 @@ linter:
     - test_types_in_equals
     - throw_in_finally
     # - type_annotate_public_apis # subset of always_specify_types
-    # ENABLE - type_init_formals
+    - type_init_formals
     # - unawaited_futures # too many false positives
     # - unnecessary_await_in_return # not yet tested
     - unnecessary_brace_in_string_interps

--- a/lib/src/iterables/count.dart
+++ b/lib/src/iterables/count.dart
@@ -21,7 +21,7 @@ Iterable<num> count([num start = 0, num step = 1]) => new _Count(start, step);
 class _Count extends InfiniteIterable<num> {
   final num start, step;
 
-  _Count(num this.start, num this.step);
+  _Count(this.start, this.step);
 
   @override
   Iterator<num> get iterator => new _CountIterator(start, step);
@@ -34,7 +34,7 @@ class _CountIterator implements Iterator<num> {
   final num _start, _step;
   num _current;
 
-  _CountIterator(num this._start, this._step);
+  _CountIterator(this._start, this._step);
 
   @override
   num get current => _current;

--- a/lib/src/iterables/generating_iterable.dart
+++ b/lib/src/iterables/generating_iterable.dart
@@ -59,7 +59,7 @@ class _GeneratingIterator<T> implements Iterator<T> {
   T object;
   bool started = false;
 
-  _GeneratingIterator(T this.object, this.next);
+  _GeneratingIterator(this.object, this.next);
 
   @override
   T get current => started ? object : null;

--- a/lib/testing/src/time/time.dart
+++ b/lib/testing/src/time/time.dart
@@ -27,7 +27,7 @@ class FakeStopwatch implements Stopwatch {
   @override
   int frequency;
 
-  FakeStopwatch(int now(), int this.frequency)
+  FakeStopwatch(int now(), this.frequency)
       : _now = now,
         _start = null,
         _stop = null;


### PR DESCRIPTION
Specifying types on initializing formals is redundant with the types on
the field declarations.