### PR TITLE
Sort constructors before other members

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -134,7 +134,7 @@ linter:
     - recursive_getters
     - slash_for_doc_comments
     # - sort_child_properties_last # not yet tested
-    # ENABLE - sort_constructors_first
+    - sort_constructors_first
     - sort_pub_dependencies
     - sort_unnamed_constructors_first
     - test_types_in_equals

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -60,10 +60,10 @@ DeclarationMirror getDeclaration(ClassMirror classMirror, Symbol name) {
 
 /// Closurizes a method reflectively.
 class Method /* implements Function */ {
+  Method(this.mirror, this.symbol);
+
   final InstanceMirror mirror;
   final Symbol symbol;
-
-  Method(this.mirror, this.symbol);
 
   @override
   dynamic noSuchMethod(Invocation invocation) {

--- a/lib/pattern.dart
+++ b/lib/pattern.dart
@@ -37,10 +37,10 @@ Pattern matchAny(Iterable<Pattern> include, {Iterable<Pattern> exclude}) =>
     _MultiPattern(include, exclude: exclude);
 
 class _MultiPattern extends Pattern {
+  _MultiPattern(this.include, {this.exclude});
+
   final Iterable<Pattern> include;
   final Iterable<Pattern> exclude;
-
-  _MultiPattern(this.include, {this.exclude});
 
   @override
   Iterable<Match> allMatches(String str, [int start = 0]) {

--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -35,9 +35,9 @@ part of quiver.async;
 Stream<T> concat<T>(Iterable<Stream<T>> streams) => _ConcatStream(streams);
 
 class _ConcatStream<T> extends Stream<T> {
-  final Iterable<Stream<T>> _streams;
-
   _ConcatStream(Iterable<Stream<T>> streams) : _streams = streams;
+
+  final Iterable<Stream<T>> _streams;
 
   @override
   StreamSubscription<T> listen(void onData(T data),

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -21,16 +21,6 @@ part of quiver.async;
 /// timer you can get the [remaining] and [elapsed] time, or [cancel] the
 /// timer.
 class CountdownTimer extends Stream<CountdownTimer> {
-  static const _THRESHOLD_MS = 4;
-
-  final Duration _duration;
-  final Stopwatch _stopwatch;
-
-  /// The duration between timer events.
-  final Duration increment;
-  final StreamController<CountdownTimer> _controller;
-  Timer _timer;
-
   /// Creates a new [CountdownTimer] that fires events in increments of
   /// [increment], until the [duration] has passed.
   ///
@@ -44,6 +34,16 @@ class CountdownTimer extends Stream<CountdownTimer> {
     _timer = Timer.periodic(increment, _tick);
     _stopwatch.start();
   }
+
+  static const _THRESHOLD_MS = 4;
+
+  final Duration _duration;
+  final Stopwatch _stopwatch;
+
+  /// The duration between timer events.
+  final Duration increment;
+  final StreamController<CountdownTimer> _controller;
+  Timer _timer;
 
   @override
   StreamSubscription<CountdownTimer> listen(void onData(CountdownTimer event),

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -32,12 +32,6 @@ part of quiver.async;
 ///     var futureOfStream = getResource().then((resource) => resource.stream);
 ///     return FutureStream(futureOfStream);
 class FutureStream<T> extends Stream<T> {
-  static T _identity<T>(T t) => t;
-
-  Future<Stream<T>> _future;
-  StreamController<T> _controller;
-  StreamSubscription<T> _subscription;
-
   FutureStream(Future<Stream<T>> future, {bool broadcast = false}) {
     _future = future.then(_identity, onError: (e, stackTrace) {
       // Since [controller] is synchronous, it's likely that emitting an error
@@ -57,6 +51,12 @@ class FutureStream<T> extends Stream<T> {
           sync: true, onListen: _onListen, onCancel: _onCancel);
     }
   }
+
+  static T _identity<T>(T t) => t;
+
+  Future<Stream<T>> _future;
+  StreamController<T> _controller;
+  StreamSubscription<T> _subscription;
 
   void _onListen() {
     _future.then((stream) {

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -48,20 +48,6 @@ part of quiver.async;
 ///     2014-05-04 20:06:00.423
 ///     ...
 class Metronome extends Stream<DateTime> {
-  static final DateTime _epoch = DateTime.fromMillisecondsSinceEpoch(0);
-
-  final Clock clock;
-  final Duration interval;
-  final DateTime anchor;
-
-  Timer _timer;
-  StreamController<DateTime> _controller;
-  final int _intervalMs;
-  final int _anchorMs;
-
-  @override
-  bool get isBroadcast => true;
-
   Metronome.epoch(Duration interval, {Clock clock = const Clock()})
       : this._(interval, clock: clock, anchor: _epoch);
 
@@ -81,6 +67,20 @@ class Metronome extends Stream<DateTime> {
           _startTimer(clock.now());
         });
   }
+
+  static final DateTime _epoch = DateTime.fromMillisecondsSinceEpoch(0);
+
+  final Clock clock;
+  final Duration interval;
+  final DateTime anchor;
+
+  Timer _timer;
+  StreamController<DateTime> _controller;
+  final int _intervalMs;
+  final int _anchorMs;
+
+  @override
+  bool get isBroadcast => true;
 
   @override
   StreamSubscription<DateTime> listen(void onData(DateTime event),

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -17,10 +17,10 @@ part of quiver.async;
 /// Underflow errors happen when the socket feeding a buffer is finished while
 /// there are still blocked readers. Each reader will complete with this error.
 class UnderflowError extends Error {
-  final String message;
-
   /// The [message] describes the underflow.
   UnderflowError([this.message]);
+
+  final String message;
 
   @override
   String toString() {
@@ -45,6 +45,13 @@ class UnderflowError extends Error {
 /// Throws [UnderflowError] if [throwOnError] is true. Useful for unexpected
 /// [Socket] disconnects.
 class StreamBuffer<T> implements StreamConsumer<List<T>> {
+  /// Create a stream buffer with optional, soft [limit] to the amount of data
+  /// the buffer will hold before pausing the underlying stream. A limit of 0
+  /// means no buffer limits.
+  StreamBuffer({bool throwOnError = false, int limit = 0})
+      : _throwOnError = throwOnError,
+        _limit = limit;
+
   int _offset = 0;
   int _counter = 0; // sum(_chunks[*].length) - _offset
   final List<T> _chunks = [];
@@ -71,13 +78,6 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
   int get limit => _limit;
 
   bool get limited => _limit > 0;
-
-  /// Create a stream buffer with optional, soft [limit] to the amount of data
-  /// the buffer will hold before pausing the underlying stream. A limit of 0
-  /// means no buffer limits.
-  StreamBuffer({bool throwOnError = false, int limit = 0})
-      : _throwOnError = throwOnError,
-        _limit = limit;
 
   /// The amount of unread data buffered.
   int get buffered => _counter;
@@ -181,7 +181,8 @@ class StreamBuffer<T> implements StreamConsumer<List<T>> {
 }
 
 class _ReaderInWaiting<T> {
+  _ReaderInWaiting(this.size, this.completer);
+
   int size;
   Completer<T> completer;
-  _ReaderInWaiting(this.size, this.completer);
 }

--- a/lib/src/async/stream_router.dart
+++ b/lib/src/async/stream_router.dart
@@ -32,17 +32,17 @@ part of quiver.async;
 ///    var onAltClick = router.route((e) => e.altKey);
 ///    var onOtherClick router.defaultStream;
 class StreamRouter<T> {
+  /// Create a new StreamRouter that listens to the [incoming] stream.
+  StreamRouter(Stream<T> incoming) : _incoming = incoming {
+    _subscription = _incoming.listen(_handle, onDone: close);
+  }
+
   final Stream<T> _incoming;
   StreamSubscription<T> _subscription;
 
   final List<_Route<T>> _routes = <_Route<T>>[];
   final StreamController<T> _defaultController =
       StreamController<T>.broadcast();
-
-  /// Create a new StreamRouter that listens to the [incoming] stream.
-  StreamRouter(Stream<T> incoming) : _incoming = incoming {
-    _subscription = _incoming.listen(_handle, onDone: close);
-  }
 
   /// Events that match [predicate] are sent to the stream created by this
   /// method, and not sent to any other router streams.
@@ -71,8 +71,8 @@ class StreamRouter<T> {
 typedef _Predicate<T> = bool Function(T event);
 
 class _Route<T> {
+  _Route(this.predicate, this.controller);
+
   final _Predicate<T> predicate;
   final StreamController<T> controller;
-
-  _Route(this.predicate, this.controller);
 }

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -16,11 +16,6 @@ part of quiver.cache;
 
 /// A [Cache] that's backed by a [Map].
 class MapCache<K, V> implements Cache<K, V> {
-  final Map<K, V> _map;
-
-  /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
-  final _outstanding = <K, FutureOr<V>>{};
-
   /// Creates a new [MapCache], optionally using [map] as the backing [Map].
   MapCache({Map<K, V> map}) : _map = map ?? HashMap<K, V>();
 
@@ -29,6 +24,11 @@ class MapCache<K, V> implements Cache<K, V> {
   factory MapCache.lru({int maximumSize}) {
     return MapCache<K, V>(map: LruMap(maximumSize: maximumSize));
   }
+
+  final Map<K, V> _map;
+
+  /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
+  final _outstanding = <K, FutureOr<V>>{};
 
   @override
   Future<V> get(K key, {Loader<K, V> ifAbsent}) async {

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -45,12 +45,12 @@ abstract class BiMap<K, V> implements Map<K, V> {
 
 /// A hash-table based implementation of BiMap.
 class HashBiMap<K, V> implements BiMap<K, V> {
+  HashBiMap() : this._from(HashMap(), HashMap());
+  HashBiMap._from(this._map, this._inverse);
+
   final Map<K, V> _map;
   final Map<V, K> _inverse;
   BiMap<V, K> _cached;
-
-  HashBiMap() : this._from(HashMap(), HashMap());
-  HashBiMap._from(this._map, this._inverse);
 
   @override
   V operator [](Object key) => _map[key];

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -36,26 +36,17 @@ abstract class LruMap<K, V> implements Map<K, V> {
 /// Simple implementation of a linked-list entry that contains a [key] and
 /// [value].
 class _LinkedEntry<K, V> {
+  _LinkedEntry([this.key, this.value]);
+
   K key;
   V value;
 
   _LinkedEntry<K, V> next;
   _LinkedEntry<K, V> previous;
-
-  _LinkedEntry([this.key, this.value]);
 }
 
 /// A linked hash-table based implementation of [LruMap].
 class LinkedLruHashMap<K, V> implements LruMap<K, V> {
-  static const _DEFAULT_MAXIMUM_SIZE = 100;
-
-  final Map<K, _LinkedEntry<K, V>> _entries;
-
-  int _maximumSize;
-
-  _LinkedEntry<K, V> _head;
-  _LinkedEntry<K, V> _tail;
-
   /// Create a new LinkedLruHashMap with a [maximumSize].
   factory LinkedLruHashMap({int maximumSize}) =>
       LinkedLruHashMap._fromMap(HashMap<K, _LinkedEntry<K, V>>(),
@@ -65,6 +56,15 @@ class LinkedLruHashMap<K, V> implements LruMap<K, V> {
       // This pattern is used instead of a default value because we want to
       // be able to respect null values coming in from MapCache.lru.
       : _maximumSize = firstNonNull(maximumSize, _DEFAULT_MAXIMUM_SIZE);
+
+  static const _DEFAULT_MAXIMUM_SIZE = 100;
+
+  final Map<K, _LinkedEntry<K, V>> _entries;
+
+  int _maximumSize;
+
+  _LinkedEntry<K, V> _head;
+  _LinkedEntry<K, V> _tail;
 
   /// Adds all key-value pairs of [other] to this map.
   ///

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -101,8 +101,6 @@ abstract class Multimap<K, V> {
 /// Abstract base class for multimap implementations.
 abstract class _BaseMultimap<K, V, C extends Iterable<V>>
     implements Multimap<K, V> {
-  static T _id<T>(x) => x;
-
   _BaseMultimap();
 
   /// Constructs a new multimap. For each element e of [iterable], adds an
@@ -116,6 +114,8 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
       add(key(element), value(element));
     }
   }
+
+  static T _id<T>(x) => x;
 
   final Map<K, C> _map = {};
 
@@ -286,9 +286,9 @@ class SetMultimap<K, V> extends _BaseMultimap<K, V, Set<V>> {
 
 /// A [Map] that delegates its operations to an underlying multimap.
 class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
-  final _BaseMultimap<K, V, C> _multimap;
-
   _WrappedMap(this._multimap);
+
+  final _BaseMultimap<K, V, C> _multimap;
 
   @override
   C operator [](Object key) => _multimap[key];
@@ -369,11 +369,11 @@ class _WrappedMap<K, V, C extends Iterable<V>> implements Map<K, C> {
 
 /// Iterable wrapper that syncs to an underlying map.
 class _WrappedIterable<K, V, C extends Iterable<V>> implements Iterable<V> {
+  _WrappedIterable(this._map, this._key, this._delegate);
+
   final K _key;
   final Map<K, C> _map;
   C _delegate;
-
-  _WrappedIterable(this._map, this._key, this._delegate);
 
   void _addToMap() => _map[_key] = _delegate;
 

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -17,6 +17,15 @@ part of quiver.collection;
 /// A [Set] of items stored in a binary tree according to [comparator].
 /// Supports bidirectional iteration.
 abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
+  /// Create a new [TreeSet] with an ordering defined by [comparator] or the
+  /// default `(a, b) => a.compareTo(b)`.
+  factory TreeSet({Comparator<V> comparator}) {
+    comparator ??= (a, b) => (a as dynamic).compareTo(b);
+    return AvlTreeSet(comparator: comparator);
+  }
+
+  TreeSet._(this.comparator);
+
   final Comparator<V> comparator;
 
   @override
@@ -27,15 +36,6 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
 
   @override
   bool get isNotEmpty => length != 0;
-
-  /// Create a new [TreeSet] with an ordering defined by [comparator] or the
-  /// default `(a, b) => a.compareTo(b)`.
-  factory TreeSet({Comparator<V> comparator}) {
-    comparator ??= (a, b) => (a as dynamic).compareTo(b);
-    return AvlTreeSet(comparator: comparator);
-  }
-
-  TreeSet._(this.comparator);
 
   /// Returns an [BidirectionalIterator] that iterates over this tree.
   @override
@@ -79,6 +79,9 @@ enum TreeSearch {
 
 /// A node in the [TreeSet].
 abstract class _TreeNode<V> {
+  /// TreeNodes are always allocated as leafs.
+  _TreeNode({this.object});
+
   _TreeNode<V> get left;
   _TreeNode<V> get right;
 
@@ -86,9 +89,6 @@ abstract class _TreeNode<V> {
   // note.
   _TreeNode<V> get parent;
   V object;
-
-  /// TreeNodes are always allocated as leafs.
-  _TreeNode({this.object});
 
   /// Return the minimum node for the subtree
   _TreeNode<V> get minimumNode {
@@ -141,6 +141,8 @@ abstract class _TreeNode<V> {
 ///           Ronald L. Rivest, Clifford Stein.
 ///        chapter 13.2
 class AvlTreeSet<V> extends TreeSet<V> {
+  AvlTreeSet({Comparator<V> comparator}) : super._(comparator);
+
   int _length = 0;
   AvlNode<V> _root;
   // Modification count to the tree, monotonically increasing
@@ -148,8 +150,6 @@ class AvlTreeSet<V> extends TreeSet<V> {
 
   @override
   int get length => _length;
-
-  AvlTreeSet({Comparator<V> comparator}) : super._(comparator);
 
   /// Add the element to the tree.
   @override
@@ -875,22 +875,6 @@ typedef _IteratorMove = bool Function();
 /// is included in the first movement (either [moveNext] or [movePrevious]) but
 /// can optionally be excluded in the constructor.
 class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
-  static const LEFT = -1;
-  static const WALK = 0;
-  static const RIGHT = 1;
-
-  final bool reversed;
-  final AvlTreeSet<V> tree;
-  final int _modCountGuard;
-  final V anchorObject;
-  final bool inclusive;
-
-  _IteratorMove _moveNext;
-  _IteratorMove _movePrevious;
-
-  int state;
-  _TreeNode<V> _current;
-
   _AvlTreeIterator._(this.tree,
       {this.reversed = false, this.inclusive = true, this.anchorObject})
       : _modCountGuard = tree._modCount {
@@ -933,6 +917,22 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
       return state == WALK;
     };
   }
+
+  static const LEFT = -1;
+  static const WALK = 0;
+  static const RIGHT = 1;
+
+  final bool reversed;
+  final AvlTreeSet<V> tree;
+  final int _modCountGuard;
+  final V anchorObject;
+  final bool inclusive;
+
+  _IteratorMove _moveNext;
+  _IteratorMove _movePrevious;
+
+  int state;
+  _TreeNode<V> _current;
 
   @override
   V get current => (state != WALK || _current == null) ? null : _current.object;
@@ -986,6 +986,8 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
 
 /// Private class used to track element insertions in the [TreeSet].
 class AvlNode<V> extends _TreeNode<V> {
+  AvlNode({V object}) : super(object: object);
+
   AvlNode<V> _left;
   AvlNode<V> _right;
   // TODO(codefu): Remove need for [parent]; this is just an implementation note
@@ -1002,8 +1004,6 @@ class AvlNode<V> extends _TreeNode<V> {
   AvlNode<V> get parent => _parent;
 
   int get balance => _balanceFactor;
-
-  AvlNode({V object}) : super(object: object);
 
   @override
   String toString() =>

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -20,8 +20,6 @@ part of quiver.core;
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
 class Optional<T> extends IterableBase<T> {
-  final T _value;
-
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;
 
@@ -36,6 +34,8 @@ class Optional<T> extends IterableBase<T> {
   ///
   /// If [value] is null, returns [absent()].
   const Optional.fromNullable(T value) : _value = value;
+
+  final T _value;
 
   /// True when this optional contains a value.
   bool get isPresent => _value != null;

--- a/lib/src/iterables/count.dart
+++ b/lib/src/iterables/count.dart
@@ -19,9 +19,9 @@ part of quiver.iterables;
 Iterable<num> count([num start = 0, num step = 1]) => _Count(start, step);
 
 class _Count extends InfiniteIterable<num> {
-  final num start, step;
-
   _Count(this.start, this.step);
+
+  final num start, step;
 
   @override
   Iterator<num> get iterator => _CountIterator(start, step);
@@ -31,10 +31,10 @@ class _Count extends InfiniteIterable<num> {
 }
 
 class _CountIterator implements Iterator<num> {
+  _CountIterator(this._start, this._step);
+
   final num _start, _step;
   num _current;
-
-  _CountIterator(this._start, this._step);
 
   @override
   num get current => _current;

--- a/lib/src/iterables/cycle.dart
+++ b/lib/src/iterables/cycle.dart
@@ -19,9 +19,9 @@ part of quiver.iterables;
 Iterable<T> cycle<T>(Iterable<T> iterable) => _Cycle<T>(iterable);
 
 class _Cycle<T> extends InfiniteIterable<T> {
-  final Iterable<T> _iterable;
-
   _Cycle(this._iterable);
+
+  final Iterable<T> _iterable;
 
   @override
   Iterator<T> get iterator => _CycleIterator(_iterable);
@@ -36,12 +36,12 @@ class _Cycle<T> extends InfiniteIterable<T> {
 }
 
 class _CycleIterator<T> implements Iterator<T> {
-  final Iterable<T> _iterable;
-  Iterator<T> _iterator;
-
   _CycleIterator(Iterable<T> _iterable)
       : _iterable = _iterable,
         _iterator = _iterable.iterator;
+
+  final Iterable<T> _iterable;
+  Iterator<T> _iterator;
 
   @override
   T get current => _iterator.current;

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -20,10 +20,10 @@ Iterable<IndexedValue<E>> enumerate<E>(Iterable<E> iterable) =>
     EnumerateIterable<E>(iterable);
 
 class IndexedValue<V> {
+  IndexedValue(this.index, this.value);
+
   final int index;
   final V value;
-
-  IndexedValue(this.index, this.value);
 
   @override
   bool operator ==(other) =>
@@ -40,9 +40,9 @@ class IndexedValue<V> {
 /// element of [iterable] and its index. See [enumerate].
 // This was inspired by MappedIterable internal to Dart collections.
 class EnumerateIterable<V> extends IterableBase<IndexedValue<V>> {
-  final Iterable<V> _iterable;
-
   EnumerateIterable(this._iterable);
+
+  final Iterable<V> _iterable;
 
   @override
   Iterator<IndexedValue<V>> get iterator =>
@@ -72,11 +72,11 @@ class EnumerateIterable<V> extends IterableBase<IndexedValue<V>> {
 
 /// The [Iterator] returned by [EnumerateIterable.iterator].
 class EnumerateIterator<V> extends Iterator<IndexedValue<V>> {
+  EnumerateIterator(this._iterator);
+
   final Iterator<V> _iterator;
   int _index = 0;
   IndexedValue<V> _current;
-
-  EnumerateIterator(this._iterator);
 
   @override
   IndexedValue<V> get current => _current;

--- a/lib/src/iterables/generating_iterable.dart
+++ b/lib/src/iterables/generating_iterable.dart
@@ -45,21 +45,21 @@ Iterable generate(initial(), next(o)) => GeneratingIterable(initial, next);
 ///     }
 ///
 class GeneratingIterable<T> extends IterableBase<T> {
+  GeneratingIterable(this.initial, this.next);
+
   final _Initial<T> initial;
   final _Next<T> next;
-
-  GeneratingIterable(this.initial, this.next);
 
   @override
   Iterator<T> get iterator => _GeneratingIterator(initial(), next);
 }
 
 class _GeneratingIterator<T> implements Iterator<T> {
+  _GeneratingIterator(this.object, this.next);
+
   final _Next<T> next;
   T object;
   bool started = false;
-
-  _GeneratingIterator(this.object, this.next);
 
   @override
   T get current => started ? object : null;

--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -31,10 +31,10 @@ Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T> compare]) {
 }
 
 class _Merge<T> extends IterableBase<T> {
+  _Merge(this._iterables, this._compare);
+
   final Iterable<Iterable<T>> _iterables;
   final Comparator<T> _compare;
-
-  _Merge(this._iterables, this._compare);
 
   @override
   Iterator<T> get iterator => _MergeIterator<T>(
@@ -46,12 +46,12 @@ class _Merge<T> extends IterableBase<T> {
 
 /// Like [Iterator] but one element ahead.
 class _IteratorPeeker<T> {
-  final Iterator<T> _iterator;
-  bool _hasCurrent;
-
   _IteratorPeeker(Iterator<T> iterator)
       : _iterator = iterator,
         _hasCurrent = iterator.moveNext();
+
+  final Iterator<T> _iterator;
+  bool _hasCurrent;
 
   void moveNext() {
     _hasCurrent = _iterator.moveNext();
@@ -61,12 +61,12 @@ class _IteratorPeeker<T> {
 }
 
 class _MergeIterator<T> implements Iterator<T> {
+  _MergeIterator(List<Iterator<T>> iterators, this._compare)
+      : _peekers = iterators.map((i) => _IteratorPeeker(i)).toList();
+
   final List<_IteratorPeeker<T>> _peekers;
   final Comparator<T> _compare;
   T _current;
-
-  _MergeIterator(List<Iterator<T>> iterators, this._compare)
-      : _peekers = iterators.map((i) => _IteratorPeeker(i)).toList();
 
   @override
   bool moveNext() {

--- a/lib/src/iterables/min_max.dart
+++ b/lib/src/iterables/min_max.dart
@@ -65,7 +65,8 @@ Extent<T> extent<T>(Iterable<T> i, [Comparator<T> compare]) {
 }
 
 class Extent<T> {
+  Extent(this.min, this.max);
+
   final T min;
   final T max;
-  Extent(this.min, this.max);
 }

--- a/lib/src/iterables/partition.dart
+++ b/lib/src/iterables/partition.dart
@@ -20,12 +20,12 @@ Iterable<List<T>> partition<T>(Iterable<T> iterable, int size) {
 }
 
 class _Partition<T> extends IterableBase<List<T>> {
-  final Iterable<T> _iterable;
-  final int _size;
-
   _Partition(this._iterable, this._size) {
     if (_size <= 0) throw ArgumentError(_size);
   }
+
+  final Iterable<T> _iterable;
+  final int _size;
 
   @override
   Iterator<List<T>> get iterator =>
@@ -33,11 +33,11 @@ class _Partition<T> extends IterableBase<List<T>> {
 }
 
 class _PartitionIterator<T> implements Iterator<List<T>> {
+  _PartitionIterator(this._iterator, this._size);
+
   final Iterator<T> _iterator;
   final int _size;
   List<T> _current;
-
-  _PartitionIterator(this._iterator, this._size);
 
   @override
   List<T> get current => _current;

--- a/lib/src/pattern/glob.dart
+++ b/lib/src/pattern/glob.dart
@@ -26,10 +26,10 @@ part of quiver.pattern;
 ///   * '?' matches exactly one character except '/'
 ///   * '**' matches one or more characters including '/'
 class Glob implements Pattern {
+  Glob(this.pattern) : regex = _regexpFromGlobPattern(pattern);
+
   final RegExp regex;
   final String pattern;
-
-  Glob(this.pattern) : regex = _regexpFromGlobPattern(pattern);
 
   @override
   Iterable<Match> allMatches(String str, [int start = 0]) =>

--- a/lib/src/time/clock.dart
+++ b/lib/src/time/clock.dart
@@ -29,8 +29,6 @@ DateTime systemTime() => DateTime.now();
 /// exactly what time a [Clock] returns and base your test expectations on
 /// that. See specific constructors for how to supply time functions.
 class Clock {
-  final TimeFunction _time;
-
   /// Creates a clock based on the given [timeFunc].
   ///
   /// If [timeFunc] is not provided, creates [Clock] based on system clock.
@@ -42,6 +40,8 @@ class Clock {
 
   /// Creates [Clock] that returns fixed [time] value. Useful in unit-tests.
   Clock.fixed(DateTime time) : _time = (() => time);
+
+  final TimeFunction _time;
 
   /// Returns current time.
   DateTime now() => _time();

--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -272,6 +272,12 @@ class _FakeAsync implements FakeAsync {
 }
 
 class _FakeTimer implements Timer {
+  _FakeTimer._(Duration duration, this._callback, this._isPeriodic, this._time)
+      : _duration = duration < _minDuration ? _minDuration : duration,
+        _creationStackTrace = StackTrace.current {
+    _nextCall = _time._elapsed + _duration;
+  }
+
   final Duration _duration;
   final Function _callback;
   final bool _isPeriodic;
@@ -285,12 +291,6 @@ class _FakeTimer implements Timer {
   // Without some sort of delay this can lead to infinitely looping timers.
   // What do the dart VM and dart2js timers do here?
   static const _minDuration = Duration.zero;
-
-  _FakeTimer._(Duration duration, this._callback, this._isPeriodic, this._time)
-      : _duration = duration < _minDuration ? _minDuration : duration,
-        _creationStackTrace = StackTrace.current {
-    _nextCall = _time._elapsed + _duration;
-  }
 
   @override
   bool get isActive => _time._hasTimer(this);

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -53,8 +53,9 @@ const Matcher areEqualityGroups = _EqualityGroupMatcher();
 const _repetitions = 3;
 
 class _EqualityGroupMatcher extends Matcher {
-  static const failureReason = 'failureReason';
   const _EqualityGroupMatcher();
+
+  static const failureReason = 'failureReason';
 
   @override
   Description describe(Description description) =>
@@ -188,26 +189,26 @@ class _EqualityGroupMatcher extends Matcher {
 }
 
 class _NotAnInstance {
-  static const equalToNothing = _NotAnInstance._();
   const _NotAnInstance._();
+  static const equalToNothing = _NotAnInstance._();
 }
 
 class _Item {
+  _Item(this.value, this.groupName, this.itemNumber);
+
   final Object value;
   final String groupName;
   final int itemNumber;
-
-  _Item(this.value, this.groupName, this.itemNumber);
 
   @override
   String toString() => "$value [group '$groupName', item ${itemNumber + 1}]";
 }
 
 class MatchError extends Error {
-  final String message;
-
   /// The [message] describes the match error.
   MatchError([this.message]);
+
+  final String message;
 
   @override
   String toString() => message;

--- a/lib/testing/src/time/time.dart
+++ b/lib/testing/src/time/time.dart
@@ -20,17 +20,17 @@ typedef Now = int Function();
 /// A [Stopwatch] implementation that gets the current time in microseconds
 /// via a user-supplied function.
 class FakeStopwatch implements Stopwatch {
+  FakeStopwatch(int now(), this.frequency)
+      : _now = now,
+        _start = null,
+        _stop = null;
+
   final Now _now;
   int _start;
   int _stop;
 
   @override
   int frequency;
-
-  FakeStopwatch(int now(), this.frequency)
-      : _now = now,
-        _start = null,
-        _stop = null;
 
   @override
   void start() {

--- a/test/collection/delegates/iterable_test.dart
+++ b/test/collection/delegates/iterable_test.dart
@@ -18,9 +18,9 @@ import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
 class MyIterable extends DelegatingIterable<String> {
-  final Iterable<String> _delegate;
-
   MyIterable(this._delegate);
+
+  final Iterable<String> _delegate;
 
   @override
   Iterable<String> get delegate => _delegate;

--- a/test/collection/delegates/list_test.dart
+++ b/test/collection/delegates/list_test.dart
@@ -18,9 +18,9 @@ import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
 class MyList extends DelegatingList<String> {
-  final List<String> _delegate;
-
   MyList(this._delegate);
+
+  final List<String> _delegate;
 
   @override
   List<String> get delegate => _delegate;

--- a/test/collection/delegates/map_test.dart
+++ b/test/collection/delegates/map_test.dart
@@ -18,9 +18,9 @@ import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
 class MyMap extends DelegatingMap<String, int> {
-  final Map<String, int> _delegate;
-
   MyMap(this._delegate);
+
+  final Map<String, int> _delegate;
 
   @override
   Map<String, int> get delegate => _delegate;

--- a/test/collection/delegates/queue_test.dart
+++ b/test/collection/delegates/queue_test.dart
@@ -20,9 +20,9 @@ import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
 class MyQueue extends DelegatingQueue<String> {
-  final Queue<String> _delegate;
-
   MyQueue(this._delegate);
+
+  final Queue<String> _delegate;
 
   @override
   Queue<String> get delegate => _delegate;

--- a/test/collection/delegates/set_test.dart
+++ b/test/collection/delegates/set_test.dart
@@ -20,9 +20,9 @@ import 'package:quiver/collection.dart';
 import 'package:test/test.dart';
 
 class MySet extends DelegatingSet<String> {
-  final Set<String> _delegate;
-
   MySet(this._delegate);
+
+  final Set<String> _delegate;
 
   @override
   Set<String> get delegate => _delegate;

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -985,9 +985,10 @@ void main() {
 }
 
 class Pair<T> {
+  Pair(this.x, this.y) : assert(x != null && y != null);
+
   final T x;
   final T y;
-  Pair(this.x, this.y) : assert(x != null && y != null);
 
   @override
   bool operator ==(other) {

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -284,10 +284,10 @@ class _NonReflexiveObject {
 /// Test class with valid equals and hashCode methods. Testers created
 /// with instances of this class should always pass.
 class _ValidTestObject {
+  _ValidTestObject(this.aspect1, this.aspect2);
+
   int aspect1;
   int aspect2;
-
-  _ValidTestObject(this.aspect1, this.aspect2);
 
   @override
   bool operator ==(Object o) {
@@ -326,11 +326,11 @@ class _InvalidEqualsIncompatibleClassObject {
 
 /// Test class with inconsistent hashCode method.
 class _InconsistentHashCodeObject {
+  _InconsistentHashCodeObject(this._aspect1, this._aspect2);
+
   final int _aspect1;
   final int _aspect2;
   int _hashCode = 0;
-
-  _InconsistentHashCodeObject(this._aspect1, this._aspect2);
 
   @override
   int get hashCode => _hashCode++;
@@ -349,12 +349,12 @@ class _InconsistentHashCodeObject {
 
 /// Test class with invalid hashCode method.
 class _InvalidHashCodeObject {
+  _InvalidHashCodeObject(this._aspect1, this._aspect2);
+
   static int hashCodeSource = 0;
   final int _aspect1;
   final int _aspect2;
   final int _hashCode = hashCodeSource++;
-
-  _InvalidHashCodeObject(this._aspect1, this._aspect2);
 
   @override
   int get hashCode => _hashCode;
@@ -374,10 +374,10 @@ class _InvalidHashCodeObject {
 _NamedObject named(String name) => _NamedObject(name);
 
 class _NamedObject {
+  _NamedObject(this.name);
+
   final Set<String> peerNames = Set();
   final String name;
-
-  _NamedObject(this.name);
 
   void addPeers(List<String> names) {
     peerNames.addAll(names);


### PR DESCRIPTION
While we have been relatively consistent about ordering of constructors,
enabling the sort_constructors_first lint enforces consistency.