### PR TITLE
Deprecate assertCheckedMode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 2.1.2-dev
+
+   * Deprecate `assertCheckedMode`. Checked mode no longer exists in Dart 2.0
+     since the vast majority of what checked mode did is now done in the type
+     system itself. This will be removed in Quiver 3.0.0.
+
 #### 2.1.1 - 2019-11-03
 
    * Deprecate `doWhileAsync`. Existing callers should migrate to

--- a/lib/testing/src/runtime/checked_mode.dart
+++ b/lib/testing/src/runtime/checked_mode.dart
@@ -17,6 +17,7 @@ part of quiver.testing.runtime;
 /// Asserts that the current runtime has checked mode enabled.
 ///
 /// Otherwise, throws [StateError].
+@Deprecated('Checked mode is meaningless in Dart 2.0. Will be removed in 3.0.0')
 void assertCheckedMode() {
   _isCheckedMode ??= _checkForCheckedMode();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: quiver
-version: 2.1.1
+version: 2.1.2-dev
 authors:
 - Justin Fagnani <justinfagnani@google.com>
 - Yegor Jbanov <yjbanov@google.com>


### PR DESCRIPTION
Checked mode no longer exists in Dart 2.0 since the vast majority of
what checked mode did is now done in the type system itself. This will
be removed in Quiver 3.0.0.