### PR TITLE
Migrate authors to AUTHORS file

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,22 @@
+# Below is a list of people and organizations that have contributed
+# to the Quiver project. Names should be added to the list like so:
+#
+#   Name/Organization <email address>
+
+Google Inc.
+Justin Fagnani <justinfagnani@google.com>
+Yegor Jbanov <yjbanov@google.com>
+Chris Bracken <cbracken@google.com>
+Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
+David Morgan <davidmorgan@google.com>
+John McDole <codefu@google.com>
+Matan Lurey <matanl@google.com>
+Günter Zöchbauer <guenter@gzoechbauer.com>
+Sean Eagan <seaneagan1@gmail.com>
+Victor Berchet <victor@suumit.com>
+Wil Pirino <willyp@google.com>
+Adam Lofts <adam.lofts@gmail.com>
+Alec Henninger <alechenninger@gmail.com>
+Mark Fielbig <mfielbig@gmail.com>
+Lucy Gettinger <lucyget@google.com>
+Michel Feinstein <michel@feinstein.com.br>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,23 +4,6 @@ description: >-
   libraries easier and more convenient, or adds additional functionality.
 homepage: https://github.com/google/quiver-dart
 version: 2.1.2
-authors:
-- Justin Fagnani <justinfagnani@google.com>
-- Yegor Jbanov <yjbanov@google.com>
-- Chris Bracken <cbracken@google.com>
-- Alexandre Ardhuin <alexandre.ardhuin@gmail.com>
-- David Morgan <davidmorgan@google.com>
-- John McDole <codefu@google.com>
-- Matan Lurey <matanl@google.com>
-- Günter Zöchbauer <guenter@gzoechbauer.com>
-- Sean Eagan <seaneagan1@gmail.com>
-- Victor Berchet <victor@suumit.com>
-- Wil Pirino <willyp@google.com>
-- Adam Lofts <adam.lofts@gmail.com>
-- Alec Henninger <alechenninger@gmail.com>
-- Mark Fielbig <mfielbig@gmail.com>
-- Lucy Gettinger <lucyget@google.com>
-- Michel Feinstein <michel@feinstein.com.br>
 environment:
   sdk: '>=2.0.0-dev.61 <3.0.0'
 dependencies:


### PR DESCRIPTION
Pub has deprecated the authors section. This migrates authors to an
AUTHORS file instead.