### PR TITLE
Add fromValue factory constructor

### DIFF
--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -34,7 +34,14 @@ class Optional<T> extends IterableBase<T> {
   ///
   /// If [value] is null, returns [absent()].
   const Optional.fromNullable(T value) : _value = value;
-
+  
+  /// Constructs an Optional of the given [value].
+  ///
+  /// If [value] is null, returns [null].
+  factory Optional.fromValue(T value) {
+    return value != null ? Optional.fromNullable(value) : null;
+  }
+  
   final T _value;
 
   /// True when this optional contains a value.


### PR DESCRIPTION
This would save lines of code
Example:
`snaphost.data != null ? Optional.fromNullable(snaphost.data) : null`
`Optional.fromValue(snaphost.data)`