### PR TITLE
Eliminate bad use of const in Optional.transform

### DIFF
--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -89,7 +89,7 @@ class Optional<T> extends IterableBase<T> {
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
   Optional<S> transform<S>(S transformer(T value)) {
     return _value == null
-        ? const Optional.absent()
+        ? Optional<S>.absent()
         : Optional.of(transformer(_value));
   }
 
@@ -100,7 +100,7 @@ class Optional<T> extends IterableBase<T> {
   /// Returns [absent()] if the transformer returns [null].
   Optional<S> transformNullable<S>(S transformer(T value)) {
     return _value == null
-        ? const Optional.absent()
+        ? Optional<S>.absent()
         : Optional.fromNullable(transformer(_value));
   }
 

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -90,7 +90,7 @@ class Optional<T> extends IterableBase<T> {
   Optional<S> transform<S>(S transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
-        : Optional.of(transformer(_value));
+        : Optional<S>.of(transformer(_value));
   }
 
   /// Transforms the Optional value.
@@ -101,7 +101,7 @@ class Optional<T> extends IterableBase<T> {
   Optional<S> transformNullable<S>(S transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
-        : Optional.fromNullable(transformer(_value));
+        : Optional<S>.fromNullable(transformer(_value));
   }
 
   @override


### PR DESCRIPTION
It's invalid to create a const which references a type variable. The
language team decided that in order to avoid painful migration of common
Dart 1 usages such as `const []`, rather than generate an error, they
would replace the type variable with `Null`, since usually, for properly
covariant types, the result 'works'.

In cases where `transform` is chained with e.g., `or`, you can end up
with `Optional<T>.absent` replacing `T` with `Null`, but then do an
implicit covariance check on the incoming type in `or`, which should be
the `S` in `transform` but is found to be `Null`.

As a result, we revert the move to const construction in `transform` and
`transformNullable`.