### PR TITLE
Fix unnecessary use of null as initial value

### DIFF
--- a/test/async/metronome_test.dart
+++ b/test/async/metronome_test.dart
@@ -24,9 +24,10 @@ void main() {
     test('delivers events as expected', () {
       FakeAsync().run((async) {
         int callbacks = 0;
-        DateTime lastTime;
-        var sub = Metronome.epoch(aMinute,
-                clock: async.getClock(DateTime.parse('2014-05-05 20:00:30')))
+
+        // Initialize metronome with start time.
+        DateTime lastTime = DateTime.parse('2014-05-05 20:00:30');
+        var sub = Metronome.epoch(aMinute, clock: async.getClock(lastTime))
             .listen((d) {
           callbacks++;
           lastTime = d;


### PR DESCRIPTION
When testing Metronome, we maintain a lastTime variable which we update
on each beat of the metronome, then later test against expected updates.
We were previously initializing this to null, but it's equally
reasonable to set it to the clock start time as the time at 'zero-th'
(minus-first?) beat and avoid the null.