### PR TITLE
NNBD: Late initialization of MapCache in tests

### DIFF
--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -20,7 +20,7 @@ import 'package:quiver/cache.dart';
 
 void main() {
   group('MapCache', () {
-    MapCache<String, String> cache;
+    /*late*/ MapCache<String, String> cache;
 
     setUp(() {
       cache = MapCache<String, String>();


### PR DESCRIPTION
From the perspective of nullability, this avoids initialisation to null.
From the perspective of readability, initialisation now occurs closer to
use so it's clear to the reader which constructor is being called.