### PR TITLE
Add null annotations to core.Optional

### DIFF
--- a/lib/core.dart
+++ b/lib/core.dart
@@ -15,6 +15,8 @@
 /// Simple code with broad use cases.
 library quiver.core;
 
+// @dart = 2.6
+
 import 'dart:collection';
 
 part 'src/core/hash.dart';

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -26,27 +26,27 @@ class Optional<T> extends IterableBase<T> {
   /// Constructs an Optional of the given [value].
   ///
   /// Throws [ArgumentError] if [value] is null.
-  Optional.of(T value) : _value = value {
+  Optional.of(T /*!*/ value) : _value = value {
     if (_value == null) throw ArgumentError('Must not be null.');
   }
 
   /// Constructs an Optional of the given [value].
   ///
   /// If [value] is null, returns [absent()].
-  const Optional.fromNullable(T value) : _value = value;
+  const Optional.fromNullable(T /*?*/ value) : _value = value;
 
-  final T _value;
+  final T /*?*/ _value;
 
   /// True when this optional contains a value.
-  bool get isPresent => _value != null;
+  bool /*!*/ get isPresent => _value != null;
 
   /// True when this optional contains no value.
-  bool get isNotPresent => _value == null;
+  bool /*!*/ get isNotPresent => _value == null;
 
   /// Gets the Optional value.
   ///
   /// Throws [StateError] if [value] is null.
-  T get value {
+  T /*!*/ get value {
     if (_value == null) {
       throw StateError('value called on absent Optional.');
     }
@@ -54,7 +54,7 @@ class Optional<T> extends IterableBase<T> {
   }
 
   /// Executes a function if the Optional value is present.
-  void ifPresent(void ifPresent(T value)) {
+  void ifPresent(void ifPresent(T /*!*/ value)) {
     if (isPresent) {
       ifPresent(_value);
     }
@@ -72,7 +72,7 @@ class Optional<T> extends IterableBase<T> {
   /// The default is returned if the Optional is [absent()].
   ///
   /// Throws [ArgumentError] if [defaultValue] is null.
-  T or(T defaultValue) {
+  T /*!*/ or(T /*!*/ defaultValue) {
     if (defaultValue == null) {
       throw ArgumentError('defaultValue must not be null.');
     }
@@ -80,14 +80,14 @@ class Optional<T> extends IterableBase<T> {
   }
 
   /// Gets the Optional value, or [null] if there is none.
-  T get orNull => _value;
+  T /*?*/ get orNull => _value;
 
   /// Transforms the Optional value.
   ///
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
-  Optional<S> transform<S>(S transformer(T value)) {
+  Optional<S> /*!*/ transform<S>(S /*!*/ transformer(T /*!*/ value)) {
     return _value == null
         ? Optional<S>.absent()
         : Optional<S>.of(transformer(_value));
@@ -98,26 +98,27 @@ class Optional<T> extends IterableBase<T> {
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// Returns [absent()] if the transformer returns [null].
-  Optional<S> transformNullable<S>(S transformer(T value)) {
+  Optional<S> /*!*/ transformNullable<S>(S /*?*/ transformer(T /*!*/ value)) {
     return _value == null
         ? Optional<S>.absent()
         : Optional<S>.fromNullable(transformer(_value));
   }
 
   @override
-  Iterator<T> get iterator =>
-      isPresent ? <T>[_value].iterator : Iterable<T>.empty().iterator;
+  Iterator<T> /*!*/ get iterator => isPresent
+      ? <T /*!*/ >[_value].iterator
+      : Iterable<T /*!*/ >.empty().iterator;
 
   /// Delegates to the underlying [value] hashCode.
   @override
-  int get hashCode => _value.hashCode;
+  int /*!*/ get hashCode => _value.hashCode;
 
   /// Delegates to the underlying [value] operator==.
   @override
-  bool operator ==(o) => o is Optional<T> && o._value == _value;
+  bool /*!*/ operator ==(o) => o is Optional<T> && o._value == _value;
 
   @override
-  String toString() {
+  String /*!*/ toString() {
     return _value == null
         ? 'Optional { absent }'
         : 'Optional { value: $_value }';


### PR DESCRIPTION
This adds nullability assertions to Optional in preparation for
migration to non-null by default in Dart.

The reason that we extend IterableBase<T> rather than IterableBase<T?>
is that Optional.expand eliminates any nulls.

Once NNBD is available, the utility of this class is limited and we
should consider deprecating it.

This is work towards #606.