### PR TITLE
Update authors location in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,5 +29,5 @@ the process as smooth as possible, we request the following:
    * During code review, go ahead and pile up commits addressing review
      comments. Once you get an LGTM (looks good to me) on the review, we'll
      squash your commits and merge!
-   * If you're not already listed as an author in `pubspec.yaml`, remember to
+   * If you're not already listed as an author in `AUTHORS`, remember to
      add yourself and claim your rightful place amongst the Quiverati.


### PR DESCRIPTION
The `authors` section has been deprecated for close to a year at this
point. We removed it in #572. This updates the contributors guide to
point code authors to the right location to add their name.