### PR TITLE
Add Directory type check in visitDirectory

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -54,7 +54,7 @@ Future visitDirectory(Directory dir, Future<bool> visit(FileSystemEntity f)) {
                   _list(Directory(entity.path));
                 }
               }
-            } else {
+            } else if (entity is Directory) {
               _list(entity);
             }
           }


### PR DESCRIPTION
In visitDirectory in the IO library, we assume that if a filesystem
entity is not a File or a Link, that it's a Directory. This adds a type
check to ensure that's actually the case.