### PR TITLE
Prefer ArgumentError.checkNotNull to checkNotNull

### DIFF
--- a/lib/check.dart
+++ b/lib/check.dart
@@ -58,6 +58,8 @@ int checkListIndex(int index, int size, {message}) {
 
 /// Throws an [ArgumentError] if the given [reference] is `null`. Otherwise,
 /// returns the [reference] parameter.
+///
+/// Users of Dart SDK 2.1 or later should prefer [ArgumentError.checkNotNull].
 T checkNotNull<T>(T reference, {message}) {
   if (reference == null) {
     throw ArgumentError(_resolveMessage(message, 'null pointer'));

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -20,10 +20,16 @@ import 'dart:collection';
 part 'src/core/hash.dart';
 part 'src/core/optional.dart';
 
-/// Returns the first non-null argument. If all arguments are null, throws an
-/// [ArgumentError].
+/// Returns the first non-null argument.
 ///
-/// Note: if [o1] is an [Optional], this can be accomplished with `o1.or(o2)`.
+/// If all arguments are null, throws an [ArgumentError].
+///
+/// Users of Dart SDK 2.1 or later should prefer:
+///
+///     var value = o1 ?? o2 ?? o3 ?? o4;
+///     ArgumentError.checkNotNull(value);
+///
+/// If [o1] is an [Optional], this can be accomplished with `o1.or(o2)`.
 dynamic firstNonNull(o1, o2, [o3, o4]) {
   // TODO(cbracken): make this generic.
   if (o1 != null) return o1;


### PR DESCRIPTION
Dart SDK 2.1 add ArgumentError.checkNotNull that does what Quiver's
checkNotNull does. Direct users to that function in the docs for
checkNotNull and firstNonNull.

This patch does not deprecate these functions since Quiver 2.x supports
all Dart SDKs back to 2.0.0-dev.61 and we don't want to break users who
haven't moved to Dart 2.1. We can deprecate these when we land support
for non-null by default, which will bump the minimum Dart SDK to 2.10.