### PR TITLE
Use ArgumentError.checkNotNull where possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 #### 3.0.0-nullsafety
 
   * BREAKING CHANGE: This verion requires Dart SDK 2.10.0 or later.
+  * Deprecate `checkNotNull`. Users of this function should migrate to
+    `ArgumentError.checkNotNull`.
+  * Deprecate `firstNonNull`. Users of this function should migrate to
+    `var v = o1 ?? o2 ?? o3 ?? o4; ArgumentError.checkNotNull(v);`.
 
 #### 2.1.3 - 2020-02-28
 

--- a/lib/check.dart
+++ b/lib/check.dart
@@ -60,6 +60,7 @@ int checkListIndex(int index, int size, {message}) {
 /// returns the [reference] parameter.
 ///
 /// Users of Dart SDK 2.1 or later should prefer [ArgumentError.checkNotNull].
+@Deprecated('Use ArgumentError.checkNotNull. Will be removed in 4.0.0')
 T checkNotNull<T>(T reference, {message}) {
   if (reference == null) {
     throw ArgumentError(_resolveMessage(message, 'null pointer'));

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -30,6 +30,7 @@ part 'src/core/optional.dart';
 ///     ArgumentError.checkNotNull(value);
 ///
 /// If [o1] is an [Optional], this can be accomplished with `o1.or(o2)`.
+@Deprecated('Use ?? and ArgumentError.checkNotNull. Will be removed in 4.0.0')
 dynamic firstNonNull(o1, o2, [o3, o4]) {
   // TODO(cbracken): make this generic.
   if (o1 != null) return o1;

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -41,7 +41,7 @@ Future visitDirectory(Directory dir, Future<bool> visit(FileSystemEntity f)) {
     directories.putIfAbsent(dir.path, () => false);
     dir.list(followLinks: false).listen((FileSystemEntity entity) {
       var future = visit(entity);
-      // TODO(cbracken): Remove this post-NNBD.
+      // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
       if (future == null) return;
       future.then((bool recurse) {
         // recurse on directories, but not cyclic symlinks

--- a/lib/src/async/iteration.dart
+++ b/lib/src/async/iteration.dart
@@ -64,12 +64,11 @@ Future<S> _reduceAsync<S, T>(
 /// [maxTasks] calls to [action] will be pending at once.
 Future<Null> forEachAsync<T>(Iterable<T> iterable, AsyncAction<Null, T> action,
     {int maxTasks = 1}) {
-  if (maxTasks == null || maxTasks < 1) {
+  // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+  ArgumentError.checkNotNull(iterable);
+  ArgumentError.checkNotNull(maxTasks);
+  if (maxTasks < 1) {
     throw ArgumentError('maxTasks must be greater than 0, was: $maxTasks');
-  }
-
-  if (iterable == null) {
-    throw ArgumentError('iterable must not be null');
   }
 
   if (iterable.isEmpty) return Future.value();

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -162,8 +162,9 @@ class HashBiMap<K, V> implements BiMap<K, V> {
   }
 
   V _add(K key, V value, bool replace) {
-    if (key == null) throw ArgumentError('null key');
-    if (value == null) throw ArgumentError('null value');
+    // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+    ArgumentError.checkNotNull(key);
+    ArgumentError.checkNotNull(value);
     var oldValue = _map[key];
     if (oldValue == value) return value;
     if (_inverse.containsKey(value)) {

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -27,7 +27,8 @@ class Optional<T> extends IterableBase<T> {
   ///
   /// Throws [ArgumentError] if [value] is null.
   Optional.of(T value) : _value = value {
-    if (_value == null) throw ArgumentError('Must not be null.');
+    // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+    ArgumentError.checkNotNull(value);
   }
 
   /// Constructs an Optional of the given [value].
@@ -73,9 +74,8 @@ class Optional<T> extends IterableBase<T> {
   ///
   /// Throws [ArgumentError] if [defaultValue] is null.
   T or(T defaultValue) {
-    if (defaultValue == null) {
-      throw ArgumentError('defaultValue must not be null.');
-    }
+    // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+    ArgumentError.checkNotNull(defaultValue);
     return _value ?? defaultValue;
   }
 

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -68,8 +68,10 @@ String _reverse(String s) {
 /// loop('test.txt', -3) == 'txt'
 /// loop('ldwor', -3, 2) == 'world'
 String loop(String s, int from, [int to]) {
-  if (s == null || s == '') {
-    throw ArgumentError('Input string cannot be null or empty');
+  // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+  ArgumentError.checkNotNull(s);
+  if (s.isEmpty) {
+    throw ArgumentError('Input string cannot be empty');
   }
   if (to != null && to < from) {
     // TODO(cbracken): throw ArgumentError in this case.
@@ -134,8 +136,10 @@ bool isWhitespace(int rune) =>
 /// If there are an odd number of characters to pad, then the right will be
 /// padded with one more than the left.
 String center(String input, int width, String fill) {
-  if (fill == null || fill.isEmpty) {
-    throw ArgumentError('fill cannot be null or empty');
+  // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+  ArgumentError.checkNotNull(fill);
+  if (fill.isEmpty) {
+    throw ArgumentError('fill cannot be empty');
   }
   input ??= '';
   if (input.length >= width) return input;


### PR DESCRIPTION
This extracts null checks that we'll be able to remove after non-null by default migration.

This bumps the minimum SDK constraint to 2.10 and deprecates checkNotNull and firstNonNull.

Note: this patch is against the (new) `null_safety` branch.

Bug: https://github.com/google/quiver-dart/issues/606