### PR TITLE
List possible tasks in error output of task.sh

### DIFF
--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -16,6 +16,7 @@
 
 if [ "$#" == "0" ]; then
   echo -e '\033[31mAt least one task argument must be provided!\033[0m'
+  echo -e 'Valid tasks: dartfmt dartanalyzer vm_test dart2js_test dartdevc_test'
   exit 1
 fi
 


### PR DESCRIPTION
When task.sh is run without an argument, emit the possible tasks rather
than fail unhelpfully.