### PR TITLE
Eliminate use of set literal in multimap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 #### dev
 
+  * Fix: Eliminate a set literal inadvertently introduced in
+    https://github.com/google/quiver-dart/pull/359. Set literals are
+    only supported starting in Dart 2.2, but Quiver supports back to
+    Dart 2.0.
   * Switched from using part/part of to re-exporting the underlying
     libraries. We weren't making use of private symbols across files
     within lib/src. This improves readability by keeping imports with

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -187,7 +187,7 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
 
   @override
   void removeWhere(bool predicate(K key, V value)) {
-    final emptyKeys = <K>{};
+    final emptyKeys = Set<K>();
     _map.forEach((K key, Iterable<V> values) {
       _removeWhere(values, key, predicate);
       if (_map[key].isEmpty) emptyKeys.add(key);


### PR DESCRIPTION
Set literals aren't supported until Dart 2.2, but quiver supports back
to Dart 2.0.

We can migrate these as part of quiver 3.0.0.