### PR TITLE
Eliminate unnecessary lambda in Multimap

### DIFF
--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -192,7 +192,7 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
       _removeWhere(values, key, predicate);
       if (_map[key].isEmpty) emptyKeys.add(key);
     });
-    emptyKeys.forEach((emptyKey) => _map.remove(emptyKey));
+    emptyKeys.forEach(_map.remove);
   }
 
   @override


### PR DESCRIPTION
Instead call forEach with the function directly.

Fixes a lint in Multimap.