### PR TITLE
Move stringFromByteStream to async; deprecate IO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,22 @@
 #### dev
 
+  * Move `stringFromByteStream` from the IO library to the async library. The
+    original in IO has been deprecated and will be removed in 3.0.0. Users
+    should update their code to import this function from `quiver/async.dart`.
+    If both `quiver/io.dart` and `quiver.async.dart` are imported in the same
+    file, users should hide the symbol from IO as described here:
+    https://dart.dev/guides/language/language-tour#importing-only-part-of-a-library
+  * Deprecate `getFullPath`. Users should use
+    `File(path).resolveSymbolicLinksSync`. This will be removed in 3.0.0.
+  * Deprecate `visitDirectory`. This will be removed in 3.0.0. The source can be
+    copied under the terms of the Apache 2.0 license.
   * Fix: Eliminate a set literal inadvertently introduced in
-    https://github.com/google/quiver-dart/pull/359. Set literals are
-    only supported starting in Dart 2.2, but Quiver supports back to
-    Dart 2.0.
-  * Switched from using part/part of to re-exporting the underlying
-    libraries. We weren't making use of private symbols across files
-    within lib/src. This improves readability by keeping imports with
-    the code that's using them. It also allows for cross-imports within
-    lib/src if necessary.
+    https://github.com/google/quiver-dart/pull/359. Set literals are only
+    supported starting in Dart 2.2, but Quiver supports back to Dart 2.0.
+  * Switched from using part/part of to re-exporting the underlying libraries.
+    We weren't making use of private symbols across files within lib/src. This
+    improves readability by keeping imports with the code that's using them. It
+    also allows for cross-imports within lib/src if necessary.
 
 #### 2.1.3 - 2020-02-28
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ increments.
 a simple, tracking periodic stream of `DateTime` events with optional anchor
 time.
 
+`stringFromByteStream` constructs a string from a stream of byte lists.
+
 [quiver.async]: https://pub.dev/documentation/quiver/latest/quiver.async/quiver.async-library.html
 
 ## [quiver.cache][]
@@ -98,13 +100,6 @@ the ability to iterate from an arbitrary anchor, and 'nearest' search.
 a list of objects, or 2, 3, or 4 arguments respectively.
 
 [quiver.core]: https://pub.dev/documentation/quiver/latest/quiver.core/quiver.core-library.html
-
-## [quiver.io][]
-
-`visitDirectory` is a recursive directory lister that conditionally recurses
-into sub-directories based on the result of a handler function.
-
-[quiver.io]: https://pub.dev/documentation/quiver/latest/quiver.io/quiver.io-library.html
 
 ## [quiver.iterables][]
 

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -18,13 +18,16 @@ import 'dart:async';
 import 'dart:convert' show Encoding, utf8;
 import 'dart:io';
 
+import 'src/async/string.dart' as astring;
+
 ///  Converts a [Stream] of byte lists to a [String].
+@Deprecated('Moved to quiver/async.dart. This copy will be removed in 3.0.0')
 Future<String> byteStreamToString(Stream<List<int>> stream,
-    {Encoding encoding = utf8}) {
-  return stream.transform(encoding.decoder).join();
-}
+        {Encoding encoding = utf8}) =>
+    astring.byteStreamToString(stream, encoding: encoding);
 
 /// Gets the full path of [path] by using [File.fullPathSync].
+@Deprecated('Use File(path).resolveSymbolicLinksSync. Will be removed in 3.0.0')
 String getFullPath(path) => File(path).resolveSymbolicLinksSync();
 
 /// Lists the sub-directories and files of this Directory, optionally recursing
@@ -33,6 +36,7 @@ String getFullPath(path) => File(path).resolveSymbolicLinksSync();
 /// [visit] is called with a [File], [Directory] or [Link] to a directory,
 /// never a Symlink to a File. If [visit] returns true, then its argument is
 /// listed recursively.
+@Deprecated('Will be removed in 3.0.0')
 Future visitDirectory(Directory dir, Future<bool> visit(FileSystemEntity f)) {
   final completer = Completer();
   final directories = <String, bool>{dir.path: false};

--- a/lib/src/async/string.dart
+++ b/lib/src/async/string.dart
@@ -12,15 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-library quiver.async;
+import 'dart:convert' show Encoding, utf8;
 
-export 'src/async/collect.dart';
-export 'src/async/concat.dart';
-export 'src/async/countdown_timer.dart';
-export 'src/async/enumerate.dart';
-export 'src/async/future_stream.dart';
-export 'src/async/iteration.dart';
-export 'src/async/metronome.dart';
-export 'src/async/stream_buffer.dart';
-export 'src/async/stream_router.dart';
-export 'src/async/string.dart';
+///  Converts a [Stream] of byte lists to a [String].
+Future<String> byteStreamToString(Stream<List<int>> stream,
+    {Encoding encoding = utf8}) {
+  return stream.transform(encoding.decoder).join();
+}

--- a/test/async/all_tests.dart
+++ b/test/async/all_tests.dart
@@ -23,6 +23,7 @@ import 'iteration_test.dart' as iteration;
 import 'metronome_test.dart' as metronome;
 import 'stream_buffer_test.dart' as stream_buffer;
 import 'stream_router_test.dart' as stream_router;
+import 'string_test.dart' as string;
 
 void main() {
   collect.main();
@@ -34,4 +35,5 @@ void main() {
   iteration.main();
   stream_buffer.main();
   stream_router.main();
+  string.main();
 }

--- a/test/async/string_test.dart
+++ b/test/async/string_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'dart:convert' show latin1, utf8;
+
+import 'package:quiver/async.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('byteStreamToString', () {
+    test('should decode UTF8 text by default', () {
+      var string = '箙、靫';
+      var encoded = utf8.encoder.convert(string);
+      var data = [encoded.sublist(0, 3), encoded.sublist(3)];
+      var stream = Stream<List<int>>.fromIterable(data);
+      byteStreamToString(stream).then((decoded) {
+        expect(decoded, string);
+      });
+    });
+
+    test('should decode text with the specified encoding', () {
+      var string = 'blåbærgrød';
+      var encoded = latin1.encoder.convert(string);
+      var data = [encoded.sublist(0, 4), encoded.sublist(4)];
+      var stream = Stream<List<int>>.fromIterable(data);
+      byteStreamToString(stream, encoding: latin1).then((decoded) {
+        expect(decoded, string);
+      });
+    });
+  });
+}


### PR DESCRIPTION
This deprecates two of the three function in the IO library and migrates
the remaining function (which doesn't use dart:io) to the async library.

As discussed in https://github.com/google/quiver-dart/issues/621, a
survey of ~150,000 imports of quiver at Google suggests that only
stringFromByteStream is used internally. It has been moved to the async
library.

getFullPath can be replaced with File.resolveSymbolicLinksSync if used.

visitDirectory should be rewritten if any users are making use of it.
Alternatively, it and its tests can be copied to other codebases under
the terms of the Apache 2.0 license.

Eliminating these functions avoids pub.dev suggesting that quiver can't
be used for web projects.