### PR TITLE
Deprecate mirrors library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
     `File(path).resolveSymbolicLinksSync`. This will be removed in 3.0.0.
   * Deprecate `visitDirectory`. This will be removed in 3.0.0. The source can be
     copied under the terms of the Apache 2.0 license.
+  * Deprecate mirrors library. This will be removed in 3.0.0. This library was
+    written prior to Dart 1.0 and in the interim, mirrors have been found to be
+    problematic for production code.  The primary Dart runtimes today are
+    Flutter and the web. Flutter disables dart:mirrors altogether. On the web,
+    the use of mirrors disables tree-shaking since in theory almost any symbol
+    could be used reflectively; this can't be solved through static analysis --
+    one could imagine the situation where a user of a web app inputs the name of
+    a method to be reflectively invoked at runtime. Users of this code can
+    rewrite this code, or copy it into their own projects under the terms of the
+    Apache 2.0 license.
   * Fix: Eliminate a set literal inadvertently introduced in
     https://github.com/google/quiver-dart/pull/359. Set literals are only
     supported starting in Dart 2.2, but Quiver supports back to Dart 2.0.

--- a/lib/mirrors.dart
+++ b/lib/mirrors.dart
@@ -17,14 +17,17 @@ library quiver.mirrors;
 import 'dart:mirrors';
 
 /// Returns the qualified name of [t].
+@Deprecated('Will be removed in 3.0.0')
 Symbol getTypeName(Type t) => reflectClass(t).qualifiedName;
 
 /// Returns true if [o] implements [type].
+@Deprecated('Will be removed in 3.0.0')
 bool implements(Object o, Type type) =>
     classImplements(reflect(o).type, reflectClass(type));
 
 /// Returns true if the class represented by [classMirror] implements the class
 /// represented by [interfaceMirror].
+@Deprecated('Will be removed in 3.0.0')
 bool classImplements(ClassMirror classMirror, ClassMirror interfaceMirror) {
   if (classMirror == null) return false;
   if (classMirror.qualifiedName == interfaceMirror.qualifiedName) return true;
@@ -39,6 +42,7 @@ bool classImplements(ClassMirror classMirror, ClassMirror interfaceMirror) {
 ///
 /// Note that it's not possible to tell if there's an implementation via
 /// noSuchMethod().
+@Deprecated('Will be removed in 3.0.0')
 DeclarationMirror getDeclaration(ClassMirror classMirror, Symbol name) {
   if (classMirror.declarations.containsKey(name)) {
     return classMirror.declarations[name];
@@ -59,6 +63,7 @@ DeclarationMirror getDeclaration(ClassMirror classMirror, Symbol name) {
 }
 
 /// Closurizes a method reflectively.
+@Deprecated('Will be removed in 3.0.0')
 class Method /* implements Function */ {
   Method(this.mirror, this.symbol);
 


### PR DESCRIPTION
In a survey of ~150,000 imports of quiver within Google, no uses of this           
library was found. This library was written prior to Dart 1.0 and in the           
interim, mirrors have been found to be problematic for production code.            
                                                                                   
The primary Dart runtimes today are Flutter and the web. Flutter                   
disables dart:mirrors altogether. On the web, the use of mirrors                   
disables tree-shaking since in theory almost any symbol could be used              
reflectively; this can't be solved through static analysis -- one could            
imagine the situation where a user of a web app inputs the name of a               
method to be reflectively invoked at runtime.                                      
                                                                                   
Users of this code can rewrite this code, or copy it into their own                
projects under the terms of the Apache 2.0 license.

See: https://github.com/google/quiver-dart/issues/621