### PR TITLE
Enable strict linting during analysis

### DIFF
--- a/test/check_test.dart
+++ b/test/check_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(cbracken): Eliminate once checkNotNull is deleted in Quiver 4.0.0.
+// ignore_for_file: deprecated_member_use_from_same_package
 library quiver.check_test;
 
 import 'package:quiver/check.dart';

--- a/test/core/core_test.dart
+++ b/test/core/core_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO(cbracken): Eliminate once firstNonNull is deleted in Quiver 4.0.0.
+// ignore_for_file: deprecated_member_use_from_same_package
 library quiver.core_test;
 
 import 'package:quiver/core.dart';

--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -33,7 +33,7 @@ while (( "$#" )); do
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'
     echo -e 'dartanalyzer --fatal-warnings .'
-    dartanalyzer --fatal-warnings . || EXIT_CODE=$?
+    dartanalyzer --lints --fatal-warnings --fatal-infos . || EXIT_CODE=$?
     ;;
   vm_test) echo
     echo -e '\033[1mTASK: vm_test\033[22m'


### PR DESCRIPTION
Also eliminates deprecation warnings for checkNotNull and firstNonNull
in tests.