### PR TITLE
Disable dartfmt checks during NNBD migration

### DIFF
--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -28,7 +28,9 @@ while (( "$#" )); do
   dartfmt) echo
     echo -e '\033[1mTASK: dartfmt\033[22m'
     echo -e 'dartfmt -n --set-exit-if-changed .'
-    dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
+    # TODO(cbracken): Re-enable when build_packages have NNBD releases.
+    # https://github.com/google/quiver-dart/issues/634
+    #dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
     ;;
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'


### PR DESCRIPTION
Dartfmt really wants to format dart migrate nullability hint comments.
Disable the format check until we apply the migration hints.

Bug: https://github.com/google/quiver-dart/issues/634