### PR TITLE
Add nullability hints to check library

### DIFF
--- a/lib/check.dart
+++ b/lib/check.dart
@@ -71,11 +71,11 @@ T checkNotNull<T>(T reference, {message}) {
 /// Throws a [StateError] if the given [expression] is `false`.
 void checkState(bool expression, {message}) {
   if (!expression) {
-    throw StateError(_resolveMessage(message, 'failed precondition'));
+    throw StateError(_resolveMessage(message, 'failed precondition')/*!*/);
   }
 }
 
-String _resolveMessage(message, String defaultMessage) {
+String/*?*/ _resolveMessage(message, String/*?*/ defaultMessage) {
   if (message is Function) message = message();
   if (message == null) return defaultMessage;
   return message.toString();

--- a/test/check_test.dart
+++ b/test/check_test.dart
@@ -32,12 +32,11 @@ void main() {
     });
 
     group('failure', () {
-      void checkArgumentShouldFail(Function f, [String expectedMessage]) {
+      void checkArgumentShouldFail(Function f, [String/*?*/ expectedMessage]) {
         try {
           f();
           fail('Should have thrown an ArgumentError');
-        } catch (e) {
-          expect(e, isArgumentError);
+        } on ArgumentError catch (e) {
           expect(e.message, expectedMessage);
         }
       }
@@ -82,13 +81,12 @@ void main() {
     });
 
     group('failure', () {
-      void checkStateShouldFail(Function f, [String expectedMessage]) {
+      void checkStateShouldFail(Function f, [String/*?*/ expectedMessage]) {
         expectedMessage ??= 'failed precondition';
         try {
           f();
           fail('Should have thrown a StateError');
-        } catch (e) {
-          expect(e, isStateError);
+        } on StateError catch (e) {
           expect(e.message, expectedMessage);
         }
       }
@@ -128,13 +126,12 @@ void main() {
     });
 
     group('failure', () {
-      void checkNotNullShouldFail(Function f, [String expectedMessage]) {
+      void checkNotNullShouldFail(Function f, [String/*?*/ expectedMessage]) {
         expectedMessage ??= 'null pointer';
         try {
           f();
           fail('Should have thrown an ArgumentError');
-        } catch (e) {
-          expect(e, isArgumentError);
+        } on ArgumentError catch (e) {
           expect(e.message, expectedMessage);
         }
       }
@@ -178,12 +175,11 @@ void main() {
 
     group('failure', () {
       void checkListIndexShouldFail(int index, int size,
-          [message, String expectedMessage]) {
+          [message, String/*?*/ expectedMessage]) {
         try {
           checkListIndex(index, size, message: message);
           fail('Should have thrown a RangeError');
-        } catch (e) {
-          expect(e, isRangeError);
+        } on RangeError catch (e) {
           expect(
               e.message,
               expectedMessage ??


### PR DESCRIPTION
Applies nullability hits for NNBD migration to the check library.

Partial fix for #606.