### PR TITLE
Add nullability hints to strings library

### DIFF
--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -16,7 +16,7 @@ library quiver.strings;
 
 /// Returns [true] if [s] is either null, empty or is solely made of whitespace
 /// characters (as defined by [String.trim]).
-bool isBlank(String s) => s == null || s.trim().isEmpty;
+bool isBlank(String/*?*/ s) => s == null || s.trim().isEmpty;
 
 /// Returns [true] if [s] is neither null, empty nor is solely made of whitespace
 /// characters.
@@ -24,13 +24,13 @@ bool isBlank(String s) => s == null || s.trim().isEmpty;
 /// See also:
 ///
 ///  * [isBlank]
-bool isNotBlank(String s) => s != null && s.trim().isNotEmpty;
+bool isNotBlank(String/*?*/ s) => s != null && s.trim().isNotEmpty;
 
 /// Returns [true] if [s] is either null or empty.
-bool isEmpty(String s) => s == null || s.isEmpty;
+bool isEmpty(String/*?*/ s) => s == null || s.isEmpty;
 
 /// Returns [true] if [s] is a not empty string.
-bool isNotEmpty(String s) => s != null && s.isNotEmpty;
+bool isNotEmpty(String/*?*/ s) => s != null && s.isNotEmpty;
 
 /// Returns a string with characters from the given [s] in reverse order.
 ///
@@ -67,9 +67,10 @@ String _reverse(String s) {
 /// loop('ab', 0, 6) == 'ababab'
 /// loop('test.txt', -3) == 'txt'
 /// loop('ldwor', -3, 2) == 'world'
-String loop(String s, int from, [int to]) {
+String loop(String s, int from, [int/*?*/ to]) {
   // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
   ArgumentError.checkNotNull(s);
+  ArgumentError.checkNotNull(from);
   if (s.isEmpty) {
     throw ArgumentError('Input string cannot be empty');
   }
@@ -135,8 +136,9 @@ bool isWhitespace(int rune) =>
 ///
 /// If there are an odd number of characters to pad, then the right will be
 /// padded with one more than the left.
-String center(String input, int width, String fill) {
+String center(String/*?*/ input, int width, String fill) {
   // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+  ArgumentError.checkNotNull(width);
   ArgumentError.checkNotNull(fill);
   if (fill.isEmpty) {
     throw ArgumentError('fill cannot be empty');
@@ -153,7 +155,7 @@ String center(String input, int width, String fill) {
 
 /// Returns `true` if [a] and [b] are equal after being converted to lower
 /// case, or are both null.
-bool equalsIgnoreCase(String a, String b) =>
+bool equalsIgnoreCase(String/*?*/ a, String/*?*/ b) =>
     (a == null && b == null) ||
     (a != null && b != null && a.toLowerCase() == b.toLowerCase());
 

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -141,10 +141,12 @@ void main() {
       expect(loop('ab', 0, -6), 'bababa');
     });
 
-    // Corner cases
+    // TODO(cbracken): Delete this test during NNBD migration.
     test('should throw on null', () {
       expect(() => loop(null, 6, 8), throwsArgumentError);
     });
+
+    // Corner cases
     test('should throw on empty', () {
       expect(() => loop('', 6, 8), throwsArgumentError);
     });


### PR DESCRIPTION
This applies nullability hints for NNBD migration to the strings
library.

Partial fix to #606.