### PR TITLE
Add nullability hints to collection/delegates

### DIFF
--- a/lib/src/collection/delegates/iterable.dart
+++ b/lib/src/collection/delegates/iterable.dart
@@ -35,7 +35,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   }
 
   @override
-  bool contains(Object element) => delegate.contains(element);
+  bool contains(Object/*?*/ element) => delegate.contains(element);
 
   @override
   E elementAt(int index) => delegate.elementAt(index);
@@ -50,7 +50,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get first => delegate.first;
 
   @override
-  E firstWhere(bool test(E element), {E orElse()}) =>
+  E firstWhere(bool test(E element), {E orElse()/*?*/}) =>
       delegate.firstWhere(test, orElse: orElse);
 
   @override
@@ -79,7 +79,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get last => delegate.last;
 
   @override
-  E lastWhere(bool test(E element), {E orElse()}) =>
+  E lastWhere(bool test(E element), {E orElse()/*?*/}) =>
       delegate.lastWhere(test, orElse: orElse);
 
   @override
@@ -95,7 +95,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get single => delegate.single;
 
   @override
-  E singleWhere(bool test(E element), {E orElse()}) =>
+  E singleWhere(bool test(E element), {E orElse()/*?*/}) =>
       delegate.singleWhere(test, orElse: orElse);
 
   @override

--- a/lib/src/collection/delegates/list.dart
+++ b/lib/src/collection/delegates/list.dart
@@ -61,7 +61,7 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  void fillRange(int start, int end, [E fillValue]) =>
+  void fillRange(int start, int end, [E/*?*/ fillValue]) =>
       delegate.fillRange(start, end, fillValue);
 
   @override
@@ -94,11 +94,11 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   }
 
   @override
-  int lastIndexOf(E element, [int start]) =>
+  int lastIndexOf(E element, [int/*?*/ start]) =>
       delegate.lastIndexOf(element, start);
 
   @override
-  int lastIndexWhere(bool test(E element), [int start]) =>
+  int lastIndexWhere(bool test(E element), [int/*?*/ start]) =>
       delegate.lastIndexWhere(test, start);
 
   @override
@@ -107,7 +107,7 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   }
 
   @override
-  bool remove(Object value) => delegate.remove(value);
+  bool remove(Object/*?*/ value) => delegate.remove(value);
 
   @override
   E removeAt(int index) => delegate.removeAt(index);
@@ -141,11 +141,11 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
       delegate.setRange(start, end, iterable, skipCount);
 
   @override
-  void shuffle([Random random]) => delegate.shuffle(random);
+  void shuffle([Random/*?*/ random]) => delegate.shuffle(random);
 
   @override
-  void sort([int compare(E a, E b)]) => delegate.sort(compare);
+  void sort([int compare(E a, E b)/*?*/]) => delegate.sort(compare);
 
   @override
-  List<E> sublist(int start, [int end]) => delegate.sublist(start, end);
+  List<E> sublist(int start, [int/*?*/ end]) => delegate.sublist(start, end);
 }

--- a/lib/src/collection/delegates/map.dart
+++ b/lib/src/collection/delegates/map.dart
@@ -26,7 +26,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   Map<K, V> get delegate;
 
   @override
-  V operator [](Object key) => delegate[key];
+  V/*?*/ operator [](Object/*?*/ key) => delegate[key];
 
   @override
   void operator []=(K key, V value) {
@@ -54,10 +54,10 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   void clear() => delegate.clear();
 
   @override
-  bool containsKey(Object key) => delegate.containsKey(key);
+  bool containsKey(Object/*?*/ key) => delegate.containsKey(key);
 
   @override
-  bool containsValue(Object value) => delegate.containsValue(value);
+  bool containsValue(Object/*?*/ value) => delegate.containsValue(value);
 
   @override
   Iterable<Null> get entries {
@@ -94,7 +94,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   V putIfAbsent(K key, V ifAbsent()) => delegate.putIfAbsent(key, ifAbsent);
 
   @override
-  V remove(Object key) => delegate.remove(key);
+  V/*?*/ remove(Object/*?*/ key) => delegate.remove(key);
 
   @override
   void removeWhere(bool test(K key, V value)) {
@@ -103,7 +103,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   }
 
   @override
-  V update(K key, V update(V value), {V ifAbsent()}) {
+  V update(K key, V update(V value), {V ifAbsent()/*?*/}) {
     // TODO(cbracken): Dart 2.0 requires this method to be implemented.
     throw UnimplementedError('update');
   }

--- a/lib/src/collection/delegates/queue.dart
+++ b/lib/src/collection/delegates/queue.dart
@@ -53,7 +53,7 @@ abstract class DelegatingQueue<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  bool remove(Object object) => delegate.remove(object);
+  bool remove(Object/*?*/ object) => delegate.remove(object);
 
   @override
   E removeFirst() => delegate.removeFirst();

--- a/lib/src/collection/delegates/set.dart
+++ b/lib/src/collection/delegates/set.dart
@@ -45,28 +45,28 @@ abstract class DelegatingSet<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  bool containsAll(Iterable<Object> other) => delegate.containsAll(other);
+  bool containsAll(Iterable<Object/*?*/> other) => delegate.containsAll(other);
 
   @override
-  Set<E> difference(Set<Object> other) => delegate.difference(other);
+  Set<E> difference(Set<Object/*?*/> other) => delegate.difference(other);
 
   @override
-  Set<E> intersection(Set<Object> other) => delegate.intersection(other);
+  Set<E> intersection(Set<Object/*?*/> other) => delegate.intersection(other);
 
   @override
-  E lookup(Object object) => delegate.lookup(object);
+  E/*?*/ lookup(Object/*?*/ object) => delegate.lookup(object);
 
   @override
-  bool remove(Object value) => delegate.remove(value);
+  bool remove(Object/*?*/ value) => delegate.remove(value);
 
   @override
-  void removeAll(Iterable<Object> elements) => delegate.removeAll(elements);
+  void removeAll(Iterable<Object/*?*/> elements) => delegate.removeAll(elements);
 
   @override
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
   @override
-  void retainAll(Iterable<Object> elements) => delegate.retainAll(elements);
+  void retainAll(Iterable<Object/*?*/> elements) => delegate.retainAll(elements);
 
   @override
   void retainWhere(bool test(E element)) => delegate.retainWhere(test);


### PR DESCRIPTION
This applies nullability hints for NNBD migration to the delegates
libraries under the broader collection library.