### PR TITLE
Add nullability hints to testing library

### DIFF
--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -129,7 +129,7 @@ abstract class FakeAsync {
 
 class _FakeAsync implements FakeAsync {
   Duration _elapsed = Duration.zero;
-  Duration _elapsingTo;
+  Duration/*?*/ _elapsingTo;
   final Queue<Function> _microtasks = Queue();
   final Set<_FakeTimer> _timers = Set<_FakeTimer>();
 
@@ -146,8 +146,8 @@ class _FakeAsync implements FakeAsync {
       throw StateError('Cannot elapse until previous elapse is complete.');
     }
     _elapsingTo = _elapsed + duration;
-    _drainTimersWhile((_FakeTimer next) => next._nextCall <= _elapsingTo);
-    _elapseTo(_elapsingTo);
+    _drainTimersWhile((_FakeTimer next) => next._nextCall <= _elapsingTo/*!*/);
+    _elapseTo(_elapsingTo/*!*/);
     _elapsingTo = null;
   }
 
@@ -157,7 +157,7 @@ class _FakeAsync implements FakeAsync {
       throw ArgumentError('Cannot call elapse with negative duration');
     }
     _elapsed += duration;
-    if (_elapsingTo != null && _elapsed > _elapsingTo) {
+    if (_elapsingTo != null && _elapsed > _elapsingTo/*!*/) {
       _elapsingTo = _elapsed;
     }
   }
@@ -195,13 +195,13 @@ class _FakeAsync implements FakeAsync {
   dynamic run(callback(FakeAsync self)) {
     _zone ??= Zone.current.fork(specification: _zoneSpec);
     dynamic result;
-    _zone.runGuarded(() {
+    _zone/*!*/.runGuarded(() {
       result = callback(this);
     });
     return result;
   }
 
-  Zone _zone;
+  Zone/*?*/ _zone;
 
   @override
   int get periodicTimerCount =>
@@ -226,8 +226,8 @@ class _FakeAsync implements FakeAsync {
 
   void _drainTimersWhile(bool predicate(_FakeTimer timer)) {
     _drainMicrotasks();
-    _FakeTimer next;
-    while ((next = _getNextTimer()) != null && predicate(next)) {
+    _FakeTimer/*?*/ next;
+    while ((next = _getNextTimer()) != null && predicate(next/*!*/)) {
       _runTimer(next);
       _drainMicrotasks();
     }
@@ -245,7 +245,7 @@ class _FakeAsync implements FakeAsync {
     return timer;
   }
 
-  _FakeTimer _getNextTimer() {
+  _FakeTimer/*?*/ _getNextTimer() {
     return _timers.isEmpty
         ? null
         : _timers.reduce((t1, t2) => t1._nextCall <= t2._nextCall ? t1 : t2);
@@ -286,7 +286,7 @@ class _FakeTimer implements Timer {
   final bool _isPeriodic;
   final _FakeAsync _time;
   final StackTrace _creationStackTrace;
-  Duration _nextCall;
+  /*late*/ Duration _nextCall;
 
   // TODO(yjbanov): In browser JavaScript, timers can only run every 4
   // milliseconds once sufficiently nested:

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -77,12 +77,12 @@ class _EqualityGroupMatcher extends Matcher {
           Map matchState, bool verbose) =>
       mismatchDescription.add(' ${matchState[failureReason]}');
 
-  void _verifyEqualityGroups(Map<String, List> equalityGroups, Map matchState) {
+  void _verifyEqualityGroups(Map<String/*?*/, List/*?*/>/*?*/ equalityGroups, Map matchState) {
     if (equalityGroups == null) {
       throw MatchError('Equality Group must not be null');
     }
     final equalityGroupsCopy = <String, List>{};
-    equalityGroups.forEach((String groupName, List group) {
+    equalityGroups.forEach((String/*?*/ groupName, List/*?*/ group) {
       if (groupName == null) {
         throw MatchError('Group name must not be null');
       }
@@ -185,7 +185,7 @@ class _EqualityGroupMatcher extends Matcher {
 
   _Item _createItem(
           Map<String, List> equalityGroups, String groupName, int itemNumber) =>
-      _Item(equalityGroups[groupName][itemNumber], groupName, itemNumber);
+      _Item(equalityGroups[groupName]/*!*/[itemNumber], groupName, itemNumber);
 }
 
 class _NotAnInstance {
@@ -196,7 +196,7 @@ class _NotAnInstance {
 class _Item {
   _Item(this.value, this.groupName, this.itemNumber);
 
-  final Object value;
+  final Object/*?*/ value;
   final String groupName;
   final int itemNumber;
 
@@ -206,7 +206,7 @@ class _Item {
 
 class MatchError extends Error {
   /// The [message] describes the match error.
-  MatchError([this.message]);
+  MatchError([this.message = '']);
 
   final String message;
 

--- a/lib/testing/src/time/time.dart
+++ b/lib/testing/src/time/time.dart
@@ -24,8 +24,8 @@ class FakeStopwatch implements Stopwatch {
         _stop = null;
 
   final Now _now;
-  int _start;
-  int _stop;
+  int/*?*/ _start;
+  int/*?*/ _stop;
 
   @override
   int frequency;
@@ -36,7 +36,7 @@ class FakeStopwatch implements Stopwatch {
     if (_start == null) {
       _start = _now();
     } else {
-      _start = _now() - (_stop - _start);
+      _start = _now() - (_stop/*!*/ - _start/*!*/);
       _stop = null;
     }
   }
@@ -61,7 +61,7 @@ class FakeStopwatch implements Stopwatch {
     if (_start == null) {
       return 0;
     }
-    return (_stop == null) ? (_now() - _start) : (_stop - _start);
+    return (_stop == null) ? (_now() - _start/*!*/) : (_stop/*!*/ - _start/*!*/);
   }
 
   @override

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -114,7 +114,7 @@ void main() {
 
         test('should call timers at their scheduled time', () {
           FakeAsync().run((async) {
-            DateTime calledAt;
+            DateTime/*?*/ calledAt;
             var periodicCalledAt = <DateTime>[];
             Timer(elapseBy ~/ 2, () {
               calledAt = async.getClock(initialTime).now();
@@ -227,7 +227,7 @@ void main() {
 
         test('should pass the periodic timer itself to callbacks', () {
           FakeAsync().run((async) {
-            Timer passedTimer;
+            Timer/*?*/ passedTimer;
             Timer periodic = Timer.periodic(elapseBy, (timer) {
               passedTimer = timer;
             });
@@ -238,7 +238,7 @@ void main() {
 
         test('should call microtasks before advancing time', () {
           FakeAsync().run((async) {
-            DateTime calledAt;
+            DateTime/*?*/ calledAt;
             scheduleMicrotask(() {
               calledAt = async.getClock(initialTime).now();
             });
@@ -262,7 +262,7 @@ void main() {
         test('should increase negative duration timers to zero duration', () {
           FakeAsync().run((async) {
             var negativeDuration = const Duration(days: -1);
-            DateTime calledAt;
+            DateTime/*?*/ calledAt;
             Timer(negativeDuration, () {
               calledAt = async.getClock(initialTime).now();
             });
@@ -317,7 +317,7 @@ void main() {
 
         test('should work with Future.delayed', () {
           FakeAsync().run((async) {
-            int result;
+            int/*?*/ result;
             Future.delayed(elapseBy, () => result = 5);
             async.elapse(elapseBy);
             expect(result, 5);
@@ -327,7 +327,7 @@ void main() {
         test('should work with Future.timeout', () {
           FakeAsync().run((async) {
             var completer = Completer();
-            TimeoutException timeout;
+            TimeoutException/*?*/ timeout;
             completer.future.timeout(elapseBy ~/ 2).catchError((err) {
               timeout = err;
             });
@@ -648,7 +648,7 @@ void main() {
         return FakeAsync().run((async) {
           var timeout = const Duration(minutes: 1);
           int counter = 0;
-          Timer timer;
+          Timer/*?*/ timer;
           timer = Timer(timeout, () {
             counter++;
             expect(timer.isActive, isFalse,

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -19,10 +19,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('expectEquals', () {
-    _ValidTestObject reference;
-    _ValidTestObject equalObject1;
-    _ValidTestObject equalObject2;
-    _ValidTestObject notEqualObject1;
+    /*late*/ _ValidTestObject reference;
+    /*late*/ _ValidTestObject equalObject1;
+    /*late*/ _ValidTestObject equalObject2;
+    /*late*/ _ValidTestObject notEqualObject1;
 
     setUp(() {
       reference = _ValidTestObject(1, 2);
@@ -64,7 +64,7 @@ void main() {
     test('Test after adding multiple instances at once with a null', () {
       try {
         expect({
-          'bad group': [reference, equalObject1, null]
+          'bad group': <dynamic>[reference, equalObject1, null]
         }, areEqualityGroups);
         fail('Should fail with null group');
       } catch (e) {


### PR DESCRIPTION
This applies nullability hints for NNBD migration to the testing async,
equality, and time libraries.