### PR TITLE
Add nullability hints to iterables

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -25,7 +25,7 @@ linter:
     # ENABLE - always_specify_types
     - annotate_overrides
     # - avoid_annotating_with_dynamic # conflicts with always_specify_types
-    - avoid_as
+    # - avoid_as # conflicts with NNBD
     - avoid_bool_literals_in_conditional_expressions
     # - avoid_catches_without_on_clauses # we do this commonly
     # - avoid_catching_errors # we do this commonly

--- a/lib/src/iterables/count.dart
+++ b/lib/src/iterables/count.dart
@@ -16,6 +16,8 @@ import 'infinite_iterable.dart';
 
 /// Returns an infinite [Iterable] of [num]s, starting from [start] and
 /// increasing by [step].
+///
+/// Calling [Iterator.current] before [Iterator.moveNext] throws [StateError].
 Iterable<num> count([num start = 0, num step = 1]) => _Count(start, step);
 
 class _Count extends InfiniteIterable<num> {
@@ -34,14 +36,16 @@ class _CountIterator implements Iterator<num> {
   _CountIterator(this._start, this._step);
 
   final num _start, _step;
-  num _current;
+  num/*?*/ _current;
 
   @override
-  num get current => _current;
+  num get current {
+    return _current /*as num*/;
+  }
 
   @override
   bool moveNext() {
-    _current = (_current == null) ? _start : _current + _step;
+    _current = (_current == null) ? _start : _current/*!*/ + _step;
     return true;
   }
 }

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -76,10 +76,12 @@ class EnumerateIterator<V> extends Iterator<IndexedValue<V>> {
 
   final Iterator<V> _iterator;
   int _index = 0;
-  IndexedValue<V> _current;
+  IndexedValue<V>/*?*/ _current;
 
   @override
-  IndexedValue<V> get current => _current;
+  IndexedValue<V> get current {
+    return _current /*as IndexedValue<V>*/;
+  }
 
   @override
   bool moveNext() {

--- a/lib/src/iterables/generating_iterable.dart
+++ b/lib/src/iterables/generating_iterable.dart
@@ -15,7 +15,7 @@
 import 'dart:collection';
 
 typedef _Initial<T> = T Function();
-typedef _Next<T> = T Function(T value);
+typedef _Next<T> = T/*?*/ Function(T value);
 
 Iterable generate(initial(), next(o)) => GeneratingIterable(initial, next);
 
@@ -58,17 +58,20 @@ class _GeneratingIterator<T> implements Iterator<T> {
   _GeneratingIterator(this.object, this.next);
 
   final _Next<T> next;
-  T object;
+  T/*?*/ object;
   bool started = false;
 
   @override
-  T get current => started ? object : null;
+  T get current {
+    final cur = started ? object : null;
+    return cur /*as T*/;
+  }
 
   @override
   bool moveNext() {
     if (object == null) return false;
     if (started) {
-      object = next(object);
+      object = next(object/*!*/);
     } else {
       started = true;
     }

--- a/lib/src/iterables/infinite_iterable.dart
+++ b/lib/src/iterables/infinite_iterable.dart
@@ -47,14 +47,14 @@ abstract class InfiniteIterable<T> extends IterableBase<T> {
   String join([String separator = '']) => throw UnsupportedError('join');
 
   @override
-  T lastWhere(bool test(T value), {T orElse()}) =>
+  T lastWhere(bool test(T value), {T orElse()/*?*/}) =>
       throw UnsupportedError('lastWhere');
 
   @override
   T reduce(T combine(T value, T element)) => throw UnsupportedError('reduce');
 
   @override
-  T singleWhere(bool test(T value), {T orElse()}) =>
+  T singleWhere(bool test(T value), {T orElse()/*?*/}) =>
       throw UnsupportedError('singleWhere');
 
   @override

--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -24,10 +24,14 @@ import 'dart:collection';
 ///
 /// If any of the [iterables] contain null elements, an exception will be
 /// thrown.
-Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T> compare]) {
-  if (iterables.isEmpty) return const <Null>[];
-  if (iterables.every((i) => i.isEmpty)) return const <Null>[];
-  return _Merge<T>(iterables, compare ?? Comparable.compare);
+Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T>/*?*/ compare]) {
+  if (iterables.isEmpty) return <T>[];
+  if (iterables.every((i) => i.isEmpty)) return <T>[];
+  return _Merge<T>(iterables, compare ?? _compareAny);
+}
+
+int _compareAny<T>(T a, T b) {
+  return Comparable.compare(a as Comparable, b as Comparable);
 }
 
 class _Merge<T> extends IterableBase<T> {
@@ -66,12 +70,12 @@ class _MergeIterator<T> implements Iterator<T> {
 
   final List<_IteratorPeeker<T>> _peekers;
   final Comparator<T> _compare;
-  T _current;
+  T/*?*/ _current;
 
   @override
   bool moveNext() {
     // Pick the peeker that's peeking at the puniest piece
-    _IteratorPeeker<T> minIter;
+    _IteratorPeeker<T>/*?*/ minIter;
     for (final p in _peekers) {
       if (p._hasCurrent) {
         if (minIter == null || _compare(p.current, minIter.current) < 0) {
@@ -89,5 +93,7 @@ class _MergeIterator<T> implements Iterator<T> {
   }
 
   @override
-  T get current => _current;
+  T get current {
+    return _current /*as T*/;
+  }
 }

--- a/lib/src/iterables/min_max.dart
+++ b/lib/src/iterables/min_max.dart
@@ -18,9 +18,9 @@
 /// The compare function must act as a [Comparator]. If [compare] is omitted,
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
-T max<T>(Iterable<T> i, [Comparator<T> compare]) {
+T/*?*/ max<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
   if (i.isEmpty) return null;
-  final Comparator<T> _compare = compare ?? Comparable.compare;
+  final Comparator<T> _compare = compare ?? _compareAny;
   return i.reduce((a, b) => _compare(a, b) > 0 ? a : b);
 }
 
@@ -30,9 +30,9 @@ T max<T>(Iterable<T> i, [Comparator<T> compare]) {
 /// The compare function must act as a [Comparator]. If [compare] is omitted,
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
-T min<T>(Iterable<T> i, [Comparator<T> compare]) {
+T/*?*/ min<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
   if (i.isEmpty) return null;
-  final Comparator<T> _compare = compare ?? Comparable.compare;
+  final Comparator<T> _compare = compare ?? _compareAny;
   return i.reduce((a, b) => _compare(a, b) < 0 ? a : b);
 }
 
@@ -47,9 +47,9 @@ T min<T>(Iterable<T> i, [Comparator<T> compare]) {
 ///
 /// If [i] is empty, an [Extent] is returned with [:null:] values for [:min:]
 /// and [:max:], since there are no valid values for them.
-Extent<T> extent<T>(Iterable<T> i, [Comparator<T> compare]) {
+Extent<T> extent<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
   if (i.isEmpty) return Extent(null, null);
-  final Comparator<T> _compare = compare ?? Comparable.compare;
+  final Comparator<T> _compare = compare ?? _compareAny;
   var iterator = i.iterator;
   var hasNext = iterator.moveNext();
   if (!hasNext) return Extent(null, null);
@@ -65,6 +65,10 @@ Extent<T> extent<T>(Iterable<T> i, [Comparator<T> compare]) {
 class Extent<T> {
   Extent(this.min, this.max);
 
-  final T min;
-  final T max;
+  final T/*?*/ min;
+  final T/*?*/ max;
+}
+
+int _compareAny<T>(T a, T b) {
+  return Comparable.compare(a as Comparable, b as Comparable);
 }

--- a/lib/src/iterables/partition.dart
+++ b/lib/src/iterables/partition.dart
@@ -37,10 +37,16 @@ class _PartitionIterator<T> implements Iterator<List<T>> {
 
   final Iterator<T> _iterator;
   final int _size;
-  List<T> _current;
+  List<T>/*?*/ _current;
 
   @override
-  List<T> get current => _current;
+  List<T> get current {
+    // TODO(cbracken): remove post NNBD migration.
+    if (_current == null) {
+      throw StateError('Must call moveNext before current');
+    }
+    return _current /*as List<T>*/;
+  }
 
   @override
   bool moveNext() {

--- a/lib/src/iterables/range.dart
+++ b/lib/src/iterables/range.dart
@@ -22,7 +22,7 @@
 /// if provided. [step] can be negative, in which case the sequence counts down
 /// from the starting point and [stop] must be less than the starting point so
 /// that it becomes the lower bound.
-Iterable<num> range(num startOrStop, [num stop, num step]) sync* {
+Iterable<num> range(num startOrStop, [num/*?*/ stop, num/*?*/ step]) sync* {
   final start = stop == null ? 0 : startOrStop;
   stop ??= startOrStop;
   step ??= 1;

--- a/test/iterables/concat_test.dart
+++ b/test/iterables/concat_test.dart
@@ -40,6 +40,7 @@ void main() {
           [1, 2, 3, -1, -2, -3]);
     });
 
+    // TODO(cbracken): Delete post NNBD migration.
     test('should throw for null input', () {
       expect(() => concat(null), throwsNoSuchMethodError);
     });

--- a/test/iterables/generating_iterable_test.dart
+++ b/test/iterables/generating_iterable_test.dart
@@ -39,5 +39,5 @@ void main() {
 }
 
 class Node {
-  Node parent;
+  Node/*?*/ parent;
 }

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -35,7 +35,7 @@ class NaturalNumberIterator implements Iterator<int> {
 
 void main() {
   group('InfiniteIterable', () {
-    NaturalNumberIterable it;
+    /*late*/ NaturalNumberIterable it;
 
     setUp(() {
       it = NaturalNumberIterable();

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -48,7 +48,7 @@ void main() {
 
     test('should honor the comparator', () {
       var a = ['c', 'b', 'a'];
-      expect(merge([a, a], (x, y) => -x.compareTo(y)),
+      expect(merge([a, a], (String x, String y) => -x.compareTo(y)),
           ['c', 'c', 'b', 'b', 'a', 'a']);
     });
 
@@ -58,6 +58,7 @@ void main() {
       expect(merge([<String>[], a]), ['a', 'b', 'c']);
     });
 
+    // TODO(cbracken): delete this after non-null by default migration.
     test('should throw on null elements', () {
       var a = ['a', null, 'c'];
       var b = ['a', 'b', 'c'];
@@ -75,7 +76,7 @@ void main() {
     test('should handle max(a) < min(b) case', () {
       var a = <String>['a', 'b'];
       var b = <String>['c', 'd'];
-      expect(max(a).compareTo(min(b)) < 0, isTrue); // test the test
+      expect(max(a)/*!*/.compareTo(min(b)/*!*/) < 0, isTrue); // test the test
       expect(merge([a, b]), ['a', 'b', 'c', 'd']);
     });
 

--- a/test/iterables/partition_test.dart
+++ b/test/iterables/partition_test.dart
@@ -33,7 +33,7 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([1, 2, 3]));
       expect(it.moveNext(), isFalse);
-      expect(it.current, isNull);
+      expect(() => it.current, throwsStateError);
     });
 
     test('should return one partition if partition size == input size', () {
@@ -41,7 +41,7 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([1, 2, 3, 4, 5]));
       expect(it.moveNext(), isFalse);
-      expect(it.current, isNull);
+      expect(() => it.current, throwsStateError);
     });
 
     test(
@@ -53,7 +53,7 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([4, 5]));
       expect(it.moveNext(), isFalse);
-      expect(it.current, isNull);
+      expect(() => it.current, throwsStateError);
     });
   });
 }


### PR DESCRIPTION
This applies nullability hints for NNBD migration to the iterables
library.

Partial fix to #606.