### PR TITLE
Import only what's necessary in tests

### DIFF
--- a/test/async/collect_test.dart
+++ b/test/async/collect_test.dart
@@ -17,8 +17,8 @@ library quiver.async.collect_test;
 import 'dart:async';
 import 'dart:math';
 
+import 'package:quiver/src/async/collect.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('collect', () {

--- a/test/async/concat_test.dart
+++ b/test/async/concat_test.dart
@@ -16,8 +16,8 @@ library quiver.async.concat_test;
 
 import 'dart:async';
 
+import 'package:quiver/src/async/concat.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('concat', () {

--- a/test/async/countdown_timer_test.dart
+++ b/test/async/countdown_timer_test.dart
@@ -14,11 +14,11 @@
 
 library quiver.async.countdown_timer_test;
 
-import 'package:test/test.dart';
-import 'package:quiver/async.dart';
-import 'package:quiver/time.dart';
+import 'package:quiver/src/async/countdown_timer.dart';
 import 'package:quiver/testing/async.dart';
 import 'package:quiver/testing/time.dart';
+import 'package:quiver/time.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('CountdownTimer', () {

--- a/test/async/enumerate_test.dart
+++ b/test/async/enumerate_test.dart
@@ -16,8 +16,8 @@ library quiver.async.enumerate_test;
 
 import 'dart:async';
 
+import 'package:quiver/src/async/enumerate.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('enumerate', () {

--- a/test/async/future_stream_test.dart
+++ b/test/async/future_stream_test.dart
@@ -16,8 +16,8 @@ library quiver.async.future_stream_test;
 
 import 'dart:async';
 
+import 'package:quiver/src/async/future_stream.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('FutureStream', () {

--- a/test/async/iteration_test.dart
+++ b/test/async/iteration_test.dart
@@ -16,8 +16,8 @@ library quiver.async.iteration_test;
 
 import 'dart:async';
 
+import 'package:quiver/src/async/iteration.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('reduceAsync', () {

--- a/test/async/metronome_test.dart
+++ b/test/async/metronome_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.time.clock_test;
 
+import 'package:quiver/src/async/metronome.dart';
 import 'package:quiver/testing/async.dart';
-import 'package:quiver/async.dart';
 import 'package:quiver/time.dart';
 import 'package:test/test.dart';
 

--- a/test/async/stream_buffer_test.dart
+++ b/test/async/stream_buffer_test.dart
@@ -15,8 +15,9 @@
 library quiver.async.stream_buffer_test;
 
 import 'dart:async';
+
+import 'package:quiver/src/async/stream_buffer.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('StreamBuffer', () {

--- a/test/async/stream_router_test.dart
+++ b/test/async/stream_router_test.dart
@@ -16,8 +16,8 @@ library quiver.async.stream_router_test;
 
 import 'dart:async';
 
+import 'package:quiver/src/async/stream_router.dart';
 import 'package:test/test.dart';
-import 'package:quiver/async.dart';
 
 void main() {
   group('StreamRouter', () {

--- a/test/async/string_test.dart
+++ b/test/async/string_test.dart
@@ -14,7 +14,7 @@
 
 import 'dart:convert' show latin1, utf8;
 
-import 'package:quiver/async.dart';
+import 'package:quiver/src/async/string.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -15,8 +15,9 @@
 library quiver.cache.map_cache_test;
 
 import 'dart:async';
+
+import 'package:quiver/src/cache/map_cache.dart';
 import 'package:test/test.dart';
-import 'package:quiver/cache.dart';
 
 void main() {
   group('MapCache', () {

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.bimap_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/bimap.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/collection/delegates/iterable_test.dart
+++ b/test/collection/delegates/iterable_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.delegates.iterable_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/delegates/iterable.dart';
 import 'package:test/test.dart';
 
 class MyIterable extends DelegatingIterable<String> {

--- a/test/collection/delegates/list_test.dart
+++ b/test/collection/delegates/list_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.delegates.list_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/delegates/list.dart';
 import 'package:test/test.dart';
 
 class MyList extends DelegatingList<String> {

--- a/test/collection/delegates/map_test.dart
+++ b/test/collection/delegates/map_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.delegates.map_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/delegates/map.dart';
 import 'package:test/test.dart';
 
 class MyMap extends DelegatingMap<String, int> {

--- a/test/collection/delegates/queue_test.dart
+++ b/test/collection/delegates/queue_test.dart
@@ -16,7 +16,7 @@ library quiver.collection.delegates.queue_test;
 
 import 'dart:collection' show Queue;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/delegates/queue.dart';
 import 'package:test/test.dart';
 
 class MyQueue extends DelegatingQueue<String> {

--- a/test/collection/delegates/set_test.dart
+++ b/test/collection/delegates/set_test.dart
@@ -16,7 +16,7 @@ library quiver.collection.delegates.set_test;
 
 import 'dart:collection' show LinkedHashSet;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/delegates/set.dart';
 import 'package:test/test.dart';
 
 class MySet extends DelegatingSet<String> {

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.lru_map_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/lru_map.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.multimap_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/multimap.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.collection.treeset_test;
 
-import 'package:quiver/collection.dart';
+import 'package:quiver/src/collection/treeset.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/core/hash_test.dart
+++ b/test/core/hash_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.core.hash_test;
 
-import 'package:quiver/core.dart';
+import 'package:quiver/src/core/hash.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.core.optional_test;
 
-import 'package:quiver/core.dart';
+import 'package:quiver/src/core/optional.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/iterables/concat_test.dart
+++ b/test/iterables/concat_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.concat_test;
 
+import 'package:quiver/src/iterables/concat.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('concat', () {

--- a/test/iterables/count_test.dart
+++ b/test/iterables/count_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.count_test;
 
+import 'package:quiver/src/iterables/count.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('count', () {

--- a/test/iterables/cycle_test.dart
+++ b/test/iterables/cycle_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.cycle_test;
 
+import 'package:quiver/src/iterables/cycle.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('cycle', () {

--- a/test/iterables/enumerate_test.dart
+++ b/test/iterables/enumerate_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.enumerate_test;
 
+import 'package:quiver/src/iterables/enumerate.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('enumerate', () {

--- a/test/iterables/generating_iterable_test.dart
+++ b/test/iterables/generating_iterable_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.property_iterable_test;
 
+import 'package:quiver/src/iterables/generating_iterable.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('GeneratingIterable', () {

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:quiver/iterables.dart';
+import 'package:quiver/src/iterables/infinite_iterable.dart';
 import 'package:test/test.dart';
 
 class NaturalNumberIterable extends InfiniteIterable<int> {

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -14,8 +14,9 @@
 
 library quiver.iterables.merge_test;
 
+import 'package:quiver/src/iterables/merge.dart';
+import 'package:quiver/src/iterables/min_max.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('merge', () {

--- a/test/iterables/min_max_test.dart
+++ b/test/iterables/min_max_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.min_max_test;
 
+import 'package:quiver/src/iterables/min_max.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('max', () {

--- a/test/iterables/partition_test.dart
+++ b/test/iterables/partition_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.partition_test;
 
+import 'package:quiver/src/iterables/partition.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('partition', () {

--- a/test/iterables/range_test.dart
+++ b/test/iterables/range_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.iterables.range_test;
 
+import 'package:quiver/src/iterables/range.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('range', () {

--- a/test/iterables/zip_test.dart
+++ b/test/iterables/zip_test.dart
@@ -14,8 +14,9 @@
 
 library quiver.iterables.zip_test;
 
+import 'package:quiver/src/iterables/range.dart';
+import 'package:quiver/src/iterables/zip.dart';
 import 'package:test/test.dart';
-import 'package:quiver/iterables.dart';
 
 void main() {
   group('zip', () {

--- a/test/pattern/glob_test.dart
+++ b/test/pattern/glob_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.patttern.glob_test;
 
-import 'package:test/test.dart';
 import 'package:quiver/pattern.dart';
+import 'package:test/test.dart';
 
 void main() {
   group('Glob', () {

--- a/test/pattern/pattern_test.dart
+++ b/test/pattern/pattern_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.pattern_test;
 
-import 'package:test/test.dart';
 import 'package:quiver/pattern.dart';
+import 'package:test/test.dart';
 
 const _specialChars = r'\^$.|+[](){}';
 

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -16,7 +16,7 @@ library quiver.testing.async.fake_async_test;
 
 import 'dart:async';
 
-import 'package:quiver/testing/async.dart';
+import 'package:quiver/testing/src/async/fake_async.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -14,7 +14,7 @@
 
 library quiver.testing.util.equalstester;
 
-import 'package:quiver/testing/equality.dart';
+import 'package:quiver/testing/src/equality/equality.dart';
 import 'package:test/test.dart';
 
 void main() {

--- a/test/time/clock_test.dart
+++ b/test/time/clock_test.dart
@@ -14,8 +14,8 @@
 
 library quiver.time.clock_test;
 
+import 'package:quiver/src/time/clock.dart';
 import 'package:test/test.dart';
-import 'package:quiver/time.dart';
 
 Clock from(int y, int m, int d) => Clock.fixed(DateTime(y, m, d));
 


### PR DESCRIPTION
During migrations that affect the type system, piecewise migration is
currently made difficult by importing umbrella imports such as
quiver/async.dart. Instead, tests now import only the exact
sub-libraries they depend on.

Helps with #606.