### PR TITLE
Add @dart=2.9 tags to not-yet-migrated files

### DIFF
--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 /// Collection classes and related utilities.
 library quiver.collection;
 

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A simple countdown timer that fires events in regular increments until a

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A Stream that will emit the same values as the stream returned by [future]

--- a/lib/src/async/iteration.dart
+++ b/lib/src/async/iteration.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// An asynchronous callback that returns a value.

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:quiver/time.dart';

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// Underflow errors happen when the socket feeding a buffer is finished while

--- a/lib/src/async/stream_router.dart
+++ b/lib/src/async/stream_router.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// Splits a [Stream] of events into multiple Streams based on a set of

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A function that produces a value for [key], for when a [Cache] needs to

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 /// A bi-directional map whose key-value pairs form a one-to-one

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 import 'package:quiver/iterables.dart' show GeneratingIterable;

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:math' show Random;
 
 /// An associative container that maps a key to multiple values.

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 import 'package:meta/meta.dart' show visibleForTesting;

--- a/test/all_tests.dart
+++ b/test/all_tests.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.all_tests;
 
 import 'async/all_tests.dart' as async;

--- a/test/async/iteration_test.dart
+++ b/test/async/iteration_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.iteration_test;
 
 import 'dart:async';

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.cache.map_cache_test;
 
 import 'dart:async';

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.multimap_test;
 
 import 'package:quiver/collection.dart';

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.treeset_test;
 
 import 'package:quiver/collection.dart';


### PR DESCRIPTION
Applies `// @dart = 2.9` comments to any files that have not yet had
non-null by default migration hints added.

Progress on #606.