### PR TITLE
Apply non-null migration for hinted files

### DIFF
--- a/lib/async.dart
+++ b/lib/async.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async;
 
 export 'src/async/collect.dart';

--- a/lib/cache.dart
+++ b/lib/cache.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.cache;
 
 export 'src/cache/cache.dart';

--- a/lib/check.dart
+++ b/lib/check.dart
@@ -71,11 +71,11 @@ T checkNotNull<T>(T reference, {message}) {
 /// Throws a [StateError] if the given [expression] is `false`.
 void checkState(bool expression, {message}) {
   if (!expression) {
-    throw StateError(_resolveMessage(message, 'failed precondition')/*!*/);
+    throw StateError(_resolveMessage(message, 'failed precondition')!);
   }
 }
 
-String/*?*/ _resolveMessage(message, String/*?*/ defaultMessage) {
+String? _resolveMessage(message, String? defaultMessage) {
   if (message is Function) message = message();
   if (message == null) return defaultMessage;
   return message.toString();

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 /// Collection classes and related utilities.
 library quiver.collection;
 

--- a/lib/pattern.dart
+++ b/lib/pattern.dart
@@ -31,14 +31,14 @@ String escapeRegex(String str) => str.splitMapJoin(_specialChars,
 /// Returns a [Pattern] that matches against every pattern in [include] and
 /// returns all the matches. If the input string matches against any pattern in
 /// [exclude] no matches are returned.
-Pattern matchAny(Iterable<Pattern> include, {Iterable<Pattern>/*?*/ exclude}) =>
+Pattern matchAny(Iterable<Pattern> include, {Iterable<Pattern>? exclude}) =>
     _MultiPattern(include, exclude: exclude);
 
 class _MultiPattern extends Pattern {
   _MultiPattern(this.include, {this.exclude});
 
   final Iterable<Pattern> include;
-  final Iterable<Pattern>/*?*/ exclude;
+  final Iterable<Pattern>? exclude;
 
   @override
   Iterable<Match> allMatches(String str, [int start = 0]) {
@@ -47,7 +47,7 @@ class _MultiPattern extends Pattern {
       var matches = pattern.allMatches(str, start);
       if (_hasMatch(matches)) {
         if (exclude != null) {
-          for (final excludePattern in exclude/*!*/) {
+          for (final excludePattern in exclude!) {
             if (_hasMatch(excludePattern.allMatches(str, start))) {
               return [];
             }
@@ -60,7 +60,7 @@ class _MultiPattern extends Pattern {
   }
 
   @override
-  Match/*?*/ matchAsPrefix(String str, [int start = 0]) {
+  Match? matchAsPrefix(String str, [int start = 0]) {
     for (final match in allMatches(str)) {
       if (match.start == start) {
         return match;
@@ -101,7 +101,7 @@ class Glob implements Pattern {
       regex.allMatches(str, start);
 
   @override
-  Match/*?*/ matchAsPrefix(String string, [int start = 0]) =>
+  Match? matchAsPrefix(String string, [int start = 0]) =>
       regex.matchAsPrefix(string, start);
 
   bool hasMatch(String str) => regex.hasMatch(str);

--- a/lib/src/async/concat.dart
+++ b/lib/src/async/concat.dart
@@ -40,15 +40,15 @@ class _ConcatStream<T> extends Stream<T> {
   final Iterable<Stream<T>> _streams;
 
   @override
-  StreamSubscription<T> listen(void onData(T data)/*?*/,
-      {Function/*?*/ onError, void onDone()/*?*/, bool/*?*/ cancelOnError}) {
+  StreamSubscription<T> listen(void onData(T data)?,
+      {Function? onError, void onDone()?, bool? cancelOnError}) {
     cancelOnError = true == cancelOnError;
-    StreamSubscription<T>/*?*/ currentSubscription;
-    StreamController<T>/*?*/ controller;
+    StreamSubscription<T>? currentSubscription;
+    StreamController<T>? controller;
     final iterator = _streams.iterator;
 
     void nextStream(StreamController<T> controller) {
-      /*late*/ bool hasNext;
+      late final bool hasNext;
       try {
         hasNext = iterator.moveNext();
       } catch (e, s) {

--- a/lib/src/async/countdown_timer.dart
+++ b/lib/src/async/countdown_timer.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A simple countdown timer that fires events in regular increments until a

--- a/lib/src/async/future_stream.dart
+++ b/lib/src/async/future_stream.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A Stream that will emit the same values as the stream returned by [future]

--- a/lib/src/async/iteration.dart
+++ b/lib/src/async/iteration.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// An asynchronous callback that returns a value.

--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 import 'package:quiver/time.dart';

--- a/lib/src/async/stream_buffer.dart
+++ b/lib/src/async/stream_buffer.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// Underflow errors happen when the socket feeding a buffer is finished while

--- a/lib/src/async/stream_router.dart
+++ b/lib/src/async/stream_router.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// Splits a [Stream] of events into multiple Streams based on a set of

--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 
 /// A function that produces a value for [key], for when a [Cache] needs to

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:collection';
 

--- a/lib/src/collection/bimap.dart
+++ b/lib/src/collection/bimap.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 /// A bi-directional map whose key-value pairs form a one-to-one

--- a/lib/src/collection/delegates/iterable.dart
+++ b/lib/src/collection/delegates/iterable.dart
@@ -35,7 +35,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   }
 
   @override
-  bool contains(Object/*?*/ element) => delegate.contains(element);
+  bool contains(Object? element) => delegate.contains(element);
 
   @override
   E elementAt(int index) => delegate.elementAt(index);
@@ -50,7 +50,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get first => delegate.first;
 
   @override
-  E firstWhere(bool test(E element), {E orElse()/*?*/}) =>
+  E firstWhere(bool test(E element), {E orElse()?}) =>
       delegate.firstWhere(test, orElse: orElse);
 
   @override
@@ -79,7 +79,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get last => delegate.last;
 
   @override
-  E lastWhere(bool test(E element), {E orElse()/*?*/}) =>
+  E lastWhere(bool test(E element), {E orElse()?}) =>
       delegate.lastWhere(test, orElse: orElse);
 
   @override
@@ -95,7 +95,7 @@ abstract class DelegatingIterable<E> implements Iterable<E> {
   E get single => delegate.single;
 
   @override
-  E singleWhere(bool test(E element), {E orElse()/*?*/}) =>
+  E singleWhere(bool test(E element), {E orElse()?}) =>
       delegate.singleWhere(test, orElse: orElse);
 
   @override

--- a/lib/src/collection/delegates/list.dart
+++ b/lib/src/collection/delegates/list.dart
@@ -61,7 +61,7 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  void fillRange(int start, int end, [E/*?*/ fillValue]) =>
+  void fillRange(int start, int end, [E? fillValue]) =>
       delegate.fillRange(start, end, fillValue);
 
   @override
@@ -94,11 +94,11 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   }
 
   @override
-  int lastIndexOf(E element, [int/*?*/ start]) =>
+  int lastIndexOf(E element, [int? start]) =>
       delegate.lastIndexOf(element, start);
 
   @override
-  int lastIndexWhere(bool test(E element), [int/*?*/ start]) =>
+  int lastIndexWhere(bool test(E element), [int? start]) =>
       delegate.lastIndexWhere(test, start);
 
   @override
@@ -107,7 +107,7 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
   }
 
   @override
-  bool remove(Object/*?*/ value) => delegate.remove(value);
+  bool remove(Object? value) => delegate.remove(value);
 
   @override
   E removeAt(int index) => delegate.removeAt(index);
@@ -141,11 +141,11 @@ abstract class DelegatingList<E> extends DelegatingIterable<E>
       delegate.setRange(start, end, iterable, skipCount);
 
   @override
-  void shuffle([Random/*?*/ random]) => delegate.shuffle(random);
+  void shuffle([Random? random]) => delegate.shuffle(random);
 
   @override
-  void sort([int compare(E a, E b)/*?*/]) => delegate.sort(compare);
+  void sort([int compare(E a, E b)?]) => delegate.sort(compare);
 
   @override
-  List<E> sublist(int start, [int/*?*/ end]) => delegate.sublist(start, end);
+  List<E> sublist(int start, [int? end]) => delegate.sublist(start, end);
 }

--- a/lib/src/collection/delegates/map.dart
+++ b/lib/src/collection/delegates/map.dart
@@ -26,7 +26,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   Map<K, V> get delegate;
 
   @override
-  V/*?*/ operator [](Object/*?*/ key) => delegate[key];
+  V? operator [](Object? key) => delegate[key];
 
   @override
   void operator []=(K key, V value) {
@@ -54,13 +54,13 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   void clear() => delegate.clear();
 
   @override
-  bool containsKey(Object/*?*/ key) => delegate.containsKey(key);
+  bool containsKey(Object? key) => delegate.containsKey(key);
 
   @override
-  bool containsValue(Object/*?*/ value) => delegate.containsValue(value);
+  bool containsValue(Object? value) => delegate.containsValue(value);
 
   @override
-  Iterable<Null> get entries {
+  Iterable<MapEntry<K, V>> get entries {
     // TODO(cbracken): Dart 2.0 requires this method to be implemented.
     // Change Iterable<Null> to Iterable<MapEntry<K, V>> when
     // the MapEntry class has been added.
@@ -94,7 +94,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   V putIfAbsent(K key, V ifAbsent()) => delegate.putIfAbsent(key, ifAbsent);
 
   @override
-  V/*?*/ remove(Object/*?*/ key) => delegate.remove(key);
+  V? remove(Object? key) => delegate.remove(key);
 
   @override
   void removeWhere(bool test(K key, V value)) {
@@ -103,7 +103,7 @@ abstract class DelegatingMap<K, V> implements Map<K, V> {
   }
 
   @override
-  V update(K key, V update(V value), {V ifAbsent()/*?*/}) {
+  V update(K key, V update(V value), {V ifAbsent()?}) {
     // TODO(cbracken): Dart 2.0 requires this method to be implemented.
     throw UnimplementedError('update');
   }

--- a/lib/src/collection/delegates/queue.dart
+++ b/lib/src/collection/delegates/queue.dart
@@ -53,7 +53,7 @@ abstract class DelegatingQueue<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  bool remove(Object/*?*/ object) => delegate.remove(object);
+  bool remove(Object? object) => delegate.remove(object);
 
   @override
   E removeFirst() => delegate.removeFirst();

--- a/lib/src/collection/delegates/set.dart
+++ b/lib/src/collection/delegates/set.dart
@@ -45,28 +45,28 @@ abstract class DelegatingSet<E> extends DelegatingIterable<E>
   void clear() => delegate.clear();
 
   @override
-  bool containsAll(Iterable<Object/*?*/> other) => delegate.containsAll(other);
+  bool containsAll(Iterable<Object?> other) => delegate.containsAll(other);
 
   @override
-  Set<E> difference(Set<Object/*?*/> other) => delegate.difference(other);
+  Set<E> difference(Set<Object?> other) => delegate.difference(other);
 
   @override
-  Set<E> intersection(Set<Object/*?*/> other) => delegate.intersection(other);
+  Set<E> intersection(Set<Object?> other) => delegate.intersection(other);
 
   @override
-  E/*?*/ lookup(Object/*?*/ object) => delegate.lookup(object);
+  E? lookup(Object? object) => delegate.lookup(object);
 
   @override
-  bool remove(Object/*?*/ value) => delegate.remove(value);
+  bool remove(Object? value) => delegate.remove(value);
 
   @override
-  void removeAll(Iterable<Object/*?*/> elements) => delegate.removeAll(elements);
+  void removeAll(Iterable<Object?> elements) => delegate.removeAll(elements);
 
   @override
   void removeWhere(bool test(E element)) => delegate.removeWhere(test);
 
   @override
-  void retainAll(Iterable<Object/*?*/> elements) => delegate.retainAll(elements);
+  void retainAll(Iterable<Object?> elements) => delegate.retainAll(elements);
 
   @override
   void retainWhere(bool test(E element)) => delegate.retainWhere(test);

--- a/lib/src/collection/lru_map.dart
+++ b/lib/src/collection/lru_map.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 import 'package:quiver/iterables.dart' show GeneratingIterable;

--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:math' show Random;
 
 /// An associative container that maps a key to multiple values.

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 import 'dart:collection';
 
 import 'package:meta/meta.dart' show visibleForTesting;

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -19,7 +19,7 @@ import 'dart:collection';
 /// Use Optional as an alternative to allowing fields, parameters or return
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
-class Optional<T> extends IterableBase<T/*!*/> {
+class Optional<T> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;
 
@@ -27,16 +27,18 @@ class Optional<T> extends IterableBase<T/*!*/> {
   ///
   /// Throws [ArgumentError] if [value] is null.
   Optional.of(T value) : _value = value {
-    // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
+    // Disallow null even if an Optional<T?> is declared. This is most likely
+    // to happen accidentally if transform is inadvertently passed a function
+    // that returns a nullable type.
     ArgumentError.checkNotNull(value);
   }
 
   /// Constructs an Optional of the given [value].
   ///
   /// If [value] is null, returns [absent()].
-  const Optional.fromNullable(T/*?*/ value) : _value = value;
+  const Optional.fromNullable(T? value) : _value = value;
 
-  final T/*?*/ _value;
+  final T? _value;
 
   /// True when this optional contains a value.
   bool get isPresent => _value != null;
@@ -47,17 +49,17 @@ class Optional<T> extends IterableBase<T/*!*/> {
   /// Gets the Optional value.
   ///
   /// Throws [StateError] if [value] is null.
-  T/*!*/ get value {
+  T get value {
     if (_value == null) {
       throw StateError('value called on absent Optional.');
     }
-    return _value/*!*/;
+    return _value!;
   }
 
   /// Executes a function if the Optional value is present.
-  void ifPresent(void ifPresent(T/*!*/ value)) {
+  void ifPresent(void ifPresent(T value)) {
     if (isPresent) {
-      ifPresent(_value/*!*/);
+      ifPresent(_value!);
     }
   }
 
@@ -74,23 +76,21 @@ class Optional<T> extends IterableBase<T/*!*/> {
   ///
   /// Throws [ArgumentError] if [defaultValue] is null.
   T or(T defaultValue) {
-    // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
-    ArgumentError.checkNotNull(defaultValue);
     return _value ?? defaultValue;
   }
 
   /// Gets the Optional value, or [null] if there is none.
-  T/*?*/ get orNull => _value;
+  T? get orNull => _value;
 
   /// Transforms the Optional value.
   ///
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
-  Optional<S> transform<S>(S transformer(T/*!*/ value)) {
+  Optional<S> transform<S>(S transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
-        : Optional<S>.of(transformer(_value/*!*/));
+        : Optional<S>.of(transformer(_value!));
   }
 
   /// Transforms the Optional value.
@@ -98,15 +98,15 @@ class Optional<T> extends IterableBase<T/*!*/> {
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// Returns [absent()] if the transformer returns [null].
-  Optional<S> transformNullable<S>(S/*?*/ transformer(T/*!*/ value)) {
+  Optional<S> transformNullable<S>(S? transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
-        : Optional<S>.fromNullable(transformer(_value/*!*/));
+        : Optional<S>.fromNullable(transformer(_value!));
   }
 
   @override
-  Iterator<T/*!*/> get iterator =>
-      isPresent ? <T/*!*/>[_value/*!*/].iterator : Iterable<T>.empty().iterator;
+  Iterator<T> get iterator =>
+      isPresent ? <T>[_value!].iterator : Iterable<T>.empty().iterator;
 
   /// Delegates to the underlying [value] hashCode.
   @override

--- a/lib/src/iterables/count.dart
+++ b/lib/src/iterables/count.dart
@@ -36,16 +36,16 @@ class _CountIterator implements Iterator<num> {
   _CountIterator(this._start, this._step);
 
   final num _start, _step;
-  num/*?*/ _current;
+  num? _current;
 
   @override
   num get current {
-    return _current /*as num*/;
+    return _current as num;
   }
 
   @override
   bool moveNext() {
-    _current = (_current == null) ? _start : _current/*!*/ + _step;
+    _current = (_current == null) ? _start : _current! + _step;
     return true;
   }
 }

--- a/lib/src/iterables/enumerate.dart
+++ b/lib/src/iterables/enumerate.dart
@@ -76,11 +76,11 @@ class EnumerateIterator<V> extends Iterator<IndexedValue<V>> {
 
   final Iterator<V> _iterator;
   int _index = 0;
-  IndexedValue<V>/*?*/ _current;
+  IndexedValue<V>? _current;
 
   @override
   IndexedValue<V> get current {
-    return _current /*as IndexedValue<V>*/;
+    return _current as IndexedValue<V>;
   }
 
   @override

--- a/lib/src/iterables/generating_iterable.dart
+++ b/lib/src/iterables/generating_iterable.dart
@@ -15,7 +15,7 @@
 import 'dart:collection';
 
 typedef _Initial<T> = T Function();
-typedef _Next<T> = T/*?*/ Function(T value);
+typedef _Next<T> = T? Function(T value);
 
 Iterable generate(initial(), next(o)) => GeneratingIterable(initial, next);
 
@@ -58,20 +58,20 @@ class _GeneratingIterator<T> implements Iterator<T> {
   _GeneratingIterator(this.object, this.next);
 
   final _Next<T> next;
-  T/*?*/ object;
+  T? object;
   bool started = false;
 
   @override
   T get current {
     final cur = started ? object : null;
-    return cur /*as T*/;
+    return cur as T;
   }
 
   @override
   bool moveNext() {
     if (object == null) return false;
     if (started) {
-      object = next(object/*!*/);
+      object = next(object!);
     } else {
       started = true;
     }

--- a/lib/src/iterables/infinite_iterable.dart
+++ b/lib/src/iterables/infinite_iterable.dart
@@ -47,14 +47,14 @@ abstract class InfiniteIterable<T> extends IterableBase<T> {
   String join([String separator = '']) => throw UnsupportedError('join');
 
   @override
-  T lastWhere(bool test(T value), {T orElse()/*?*/}) =>
+  T lastWhere(bool test(T value), {T orElse()?}) =>
       throw UnsupportedError('lastWhere');
 
   @override
   T reduce(T combine(T value, T element)) => throw UnsupportedError('reduce');
 
   @override
-  T singleWhere(bool test(T value), {T orElse()/*?*/}) =>
+  T singleWhere(bool test(T value), {T orElse()?}) =>
       throw UnsupportedError('singleWhere');
 
   @override

--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -24,7 +24,7 @@ import 'dart:collection';
 ///
 /// If any of the [iterables] contain null elements, an exception will be
 /// thrown.
-Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T>/*?*/ compare]) {
+Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T>? compare]) {
   if (iterables.isEmpty) return <T>[];
   if (iterables.every((i) => i.isEmpty)) return <T>[];
   return _Merge<T>(iterables, compare ?? _compareAny);
@@ -70,12 +70,12 @@ class _MergeIterator<T> implements Iterator<T> {
 
   final List<_IteratorPeeker<T>> _peekers;
   final Comparator<T> _compare;
-  T/*?*/ _current;
+  T? _current;
 
   @override
   bool moveNext() {
     // Pick the peeker that's peeking at the puniest piece
-    _IteratorPeeker<T>/*?*/ minIter;
+    _IteratorPeeker<T>? minIter;
     for (final p in _peekers) {
       if (p._hasCurrent) {
         if (minIter == null || _compare(p.current, minIter.current) < 0) {
@@ -94,6 +94,6 @@ class _MergeIterator<T> implements Iterator<T> {
 
   @override
   T get current {
-    return _current /*as T*/;
+    return _current as T;
   }
 }

--- a/lib/src/iterables/min_max.dart
+++ b/lib/src/iterables/min_max.dart
@@ -18,7 +18,7 @@
 /// The compare function must act as a [Comparator]. If [compare] is omitted,
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
-T/*?*/ max<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
+T? max<T>(Iterable<T> i, [Comparator<T>? compare]) {
   if (i.isEmpty) return null;
   final Comparator<T> _compare = compare ?? _compareAny;
   return i.reduce((a, b) => _compare(a, b) > 0 ? a : b);
@@ -30,7 +30,7 @@ T/*?*/ max<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
 /// The compare function must act as a [Comparator]. If [compare] is omitted,
 /// [Comparable.compare] is used. If [i] contains null elements, an exception
 /// will be thrown.
-T/*?*/ min<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
+T? min<T>(Iterable<T> i, [Comparator<T>? compare]) {
   if (i.isEmpty) return null;
   final Comparator<T> _compare = compare ?? _compareAny;
   return i.reduce((a, b) => _compare(a, b) < 0 ? a : b);
@@ -47,7 +47,7 @@ T/*?*/ min<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
 ///
 /// If [i] is empty, an [Extent] is returned with [:null:] values for [:min:]
 /// and [:max:], since there are no valid values for them.
-Extent<T> extent<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
+Extent<T> extent<T>(Iterable<T> i, [Comparator<T>? compare]) {
   if (i.isEmpty) return Extent(null, null);
   final Comparator<T> _compare = compare ?? _compareAny;
   var iterator = i.iterator;
@@ -65,8 +65,8 @@ Extent<T> extent<T>(Iterable<T> i, [Comparator<T>/*?*/ compare]) {
 class Extent<T> {
   Extent(this.min, this.max);
 
-  final T/*?*/ min;
-  final T/*?*/ max;
+  final T? min;
+  final T? max;
 }
 
 int _compareAny<T>(T a, T b) {

--- a/lib/src/iterables/partition.dart
+++ b/lib/src/iterables/partition.dart
@@ -37,7 +37,7 @@ class _PartitionIterator<T> implements Iterator<List<T>> {
 
   final Iterator<T> _iterator;
   final int _size;
-  List<T>/*?*/ _current;
+  List<T>? _current;
 
   @override
   List<T> get current {
@@ -45,7 +45,7 @@ class _PartitionIterator<T> implements Iterator<List<T>> {
     if (_current == null) {
       throw StateError('Must call moveNext before current');
     }
-    return _current /*as List<T>*/;
+    return _current as List<T>;
   }
 
   @override

--- a/lib/src/iterables/range.dart
+++ b/lib/src/iterables/range.dart
@@ -22,7 +22,7 @@
 /// if provided. [step] can be negative, in which case the sequence counts down
 /// from the starting point and [stop] must be less than the starting point so
 /// that it becomes the lower bound.
-Iterable<num> range(num startOrStop, [num/*?*/ stop, num/*?*/ step]) sync* {
+Iterable<num> range(num startOrStop, [num? stop, num? step]) sync* {
   final start = stop == null ? 0 : startOrStop;
   stop ??= startOrStop;
   step ??= 1;

--- a/lib/src/time/util.dart
+++ b/lib/src/time/util.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'package:meta/meta.dart';
-
 /// Days in a month. This array uses 1-based month numbers, i.e. January is
 /// the 1-st element in the array, not the 0-th.
 const _daysInMonth = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
@@ -51,8 +49,8 @@ bool isLeapYear(int year) =>
 /// month back takes us to February 28 (or 29 during a leap year), as February
 /// doesn't have 31-st date.
 int clampDayOfMonth({
-  @required int year,
-  @required int month,
-  @required int day,
+  required int year,
+  required int month,
+  required int day,
 }) =>
     day.clamp(1, daysInMonth(year, month));

--- a/lib/strings.dart
+++ b/lib/strings.dart
@@ -16,7 +16,7 @@ library quiver.strings;
 
 /// Returns [true] if [s] is either null, empty or is solely made of whitespace
 /// characters (as defined by [String.trim]).
-bool isBlank(String/*?*/ s) => s == null || s.trim().isEmpty;
+bool isBlank(String? s) => s == null || s.trim().isEmpty;
 
 /// Returns [true] if [s] is neither null, empty nor is solely made of whitespace
 /// characters.
@@ -24,13 +24,13 @@ bool isBlank(String/*?*/ s) => s == null || s.trim().isEmpty;
 /// See also:
 ///
 ///  * [isBlank]
-bool isNotBlank(String/*?*/ s) => s != null && s.trim().isNotEmpty;
+bool isNotBlank(String? s) => s != null && s.trim().isNotEmpty;
 
 /// Returns [true] if [s] is either null or empty.
-bool isEmpty(String/*?*/ s) => s == null || s.isEmpty;
+bool isEmpty(String? s) => s == null || s.isEmpty;
 
 /// Returns [true] if [s] is a not empty string.
-bool isNotEmpty(String/*?*/ s) => s != null && s.isNotEmpty;
+bool isNotEmpty(String? s) => s != null && s.isNotEmpty;
 
 /// Returns a string with characters from the given [s] in reverse order.
 ///
@@ -38,7 +38,7 @@ bool isNotEmpty(String/*?*/ s) => s != null && s.isNotEmpty;
 /// sequences including zero-width joiners, etc. this function is unsafe to
 /// use. No replacement is provided.
 String _reverse(String s) {
-  if (s == null || s == '') return s;
+  if (s == '') return s;
   StringBuffer sb = StringBuffer();
   var runes = s.runes.iterator..reset(s.length);
   while (runes.movePrevious()) {
@@ -67,10 +67,7 @@ String _reverse(String s) {
 /// loop('ab', 0, 6) == 'ababab'
 /// loop('test.txt', -3) == 'txt'
 /// loop('ldwor', -3, 2) == 'world'
-String loop(String s, int from, [int/*?*/ to]) {
-  // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
-  ArgumentError.checkNotNull(s);
-  ArgumentError.checkNotNull(from);
+String loop(String s, int from, [int? to]) {
   if (s.isEmpty) {
     throw ArgumentError('Input string cannot be empty');
   }
@@ -136,10 +133,7 @@ bool isWhitespace(int rune) =>
 ///
 /// If there are an odd number of characters to pad, then the right will be
 /// padded with one more than the left.
-String center(String/*?*/ input, int width, String fill) {
-  // TODO(cbracken): Remove post-NNBD. https://github.com/google/quiver-dart/issues/612
-  ArgumentError.checkNotNull(width);
-  ArgumentError.checkNotNull(fill);
+String center(String? input, int width, String fill) {
   if (fill.isEmpty) {
     throw ArgumentError('fill cannot be empty');
   }
@@ -155,7 +149,7 @@ String center(String/*?*/ input, int width, String fill) {
 
 /// Returns `true` if [a] and [b] are equal after being converted to lower
 /// case, or are both null.
-bool equalsIgnoreCase(String/*?*/ a, String/*?*/ b) =>
+bool equalsIgnoreCase(String? a, String? b) =>
     (a == null && b == null) ||
     (a != null && b != null && a.toLowerCase() == b.toLowerCase());
 

--- a/lib/testing/src/async/fake_async.dart
+++ b/lib/testing/src/async/fake_async.dart
@@ -129,7 +129,7 @@ abstract class FakeAsync {
 
 class _FakeAsync implements FakeAsync {
   Duration _elapsed = Duration.zero;
-  Duration/*?*/ _elapsingTo;
+  Duration? _elapsingTo;
   final Queue<Function> _microtasks = Queue();
   final Set<_FakeTimer> _timers = Set<_FakeTimer>();
 
@@ -146,8 +146,8 @@ class _FakeAsync implements FakeAsync {
       throw StateError('Cannot elapse until previous elapse is complete.');
     }
     _elapsingTo = _elapsed + duration;
-    _drainTimersWhile((_FakeTimer next) => next._nextCall <= _elapsingTo/*!*/);
-    _elapseTo(_elapsingTo/*!*/);
+    _drainTimersWhile((_FakeTimer next) => next._nextCall <= _elapsingTo!);
+    _elapseTo(_elapsingTo!);
     _elapsingTo = null;
   }
 
@@ -157,7 +157,7 @@ class _FakeAsync implements FakeAsync {
       throw ArgumentError('Cannot call elapse with negative duration');
     }
     _elapsed += duration;
-    if (_elapsingTo != null && _elapsed > _elapsingTo/*!*/) {
+    if (_elapsingTo != null && _elapsed > _elapsingTo!) {
       _elapsingTo = _elapsed;
     }
   }
@@ -195,13 +195,13 @@ class _FakeAsync implements FakeAsync {
   dynamic run(callback(FakeAsync self)) {
     _zone ??= Zone.current.fork(specification: _zoneSpec);
     dynamic result;
-    _zone/*!*/.runGuarded(() {
+    _zone!.runGuarded(() {
       result = callback(this);
     });
     return result;
   }
 
-  Zone/*?*/ _zone;
+  Zone? _zone;
 
   @override
   int get periodicTimerCount =>
@@ -226,8 +226,8 @@ class _FakeAsync implements FakeAsync {
 
   void _drainTimersWhile(bool predicate(_FakeTimer timer)) {
     _drainMicrotasks();
-    _FakeTimer/*?*/ next;
-    while ((next = _getNextTimer()) != null && predicate(next/*!*/)) {
+    _FakeTimer? next;
+    while ((next = _getNextTimer()) != null && predicate(next!)) {
       _runTimer(next);
       _drainMicrotasks();
     }
@@ -245,7 +245,7 @@ class _FakeAsync implements FakeAsync {
     return timer;
   }
 
-  _FakeTimer/*?*/ _getNextTimer() {
+  _FakeTimer? _getNextTimer() {
     return _timers.isEmpty
         ? null
         : _timers.reduce((t1, t2) => t1._nextCall <= t2._nextCall ? t1 : t2);
@@ -286,7 +286,7 @@ class _FakeTimer implements Timer {
   final bool _isPeriodic;
   final _FakeAsync _time;
   final StackTrace _creationStackTrace;
-  /*late*/ Duration _nextCall;
+  late Duration _nextCall;
 
   // TODO(yjbanov): In browser JavaScript, timers can only run every 4
   // milliseconds once sufficiently nested:

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -77,12 +77,12 @@ class _EqualityGroupMatcher extends Matcher {
           Map matchState, bool verbose) =>
       mismatchDescription.add(' ${matchState[failureReason]}');
 
-  void _verifyEqualityGroups(Map<String/*?*/, List/*?*/>/*?*/ equalityGroups, Map matchState) {
+  void _verifyEqualityGroups(Map<String?, List?>? equalityGroups, Map matchState) {
     if (equalityGroups == null) {
       throw MatchError('Equality Group must not be null');
     }
     final equalityGroupsCopy = <String, List>{};
-    equalityGroups.forEach((String/*?*/ groupName, List/*?*/ group) {
+    equalityGroups.forEach((String? groupName, List? group) {
       if (groupName == null) {
         throw MatchError('Group name must not be null');
       }
@@ -185,7 +185,7 @@ class _EqualityGroupMatcher extends Matcher {
 
   _Item _createItem(
           Map<String, List> equalityGroups, String groupName, int itemNumber) =>
-      _Item(equalityGroups[groupName]/*!*/[itemNumber], groupName, itemNumber);
+      _Item(equalityGroups[groupName]![itemNumber], groupName, itemNumber);
 }
 
 class _NotAnInstance {
@@ -196,7 +196,7 @@ class _NotAnInstance {
 class _Item {
   _Item(this.value, this.groupName, this.itemNumber);
 
-  final Object/*?*/ value;
+  final Object? value;
   final String groupName;
   final int itemNumber;
 

--- a/lib/testing/src/time/time.dart
+++ b/lib/testing/src/time/time.dart
@@ -24,8 +24,8 @@ class FakeStopwatch implements Stopwatch {
         _stop = null;
 
   final Now _now;
-  int/*?*/ _start;
-  int/*?*/ _stop;
+  int? _start;
+  int? _stop;
 
   @override
   int frequency;
@@ -36,7 +36,7 @@ class FakeStopwatch implements Stopwatch {
     if (_start == null) {
       _start = _now();
     } else {
-      _start = _now() - (_stop/*!*/ - _start/*!*/);
+      _start = _now() - (_stop! - _start!);
       _stop = null;
     }
   }
@@ -61,7 +61,7 @@ class FakeStopwatch implements Stopwatch {
     if (_start == null) {
       return 0;
     }
-    return (_stop == null) ? (_now() - _start/*!*/) : (_stop/*!*/ - _start/*!*/);
+    return (_stop == null) ? (_now() - _start!) : (_stop! - _start!);
   }
 
   @override

--- a/test/async/countdown_timer_test.dart
+++ b/test/async/countdown_timer_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.countdown_timer_test;
 
 import 'package:quiver/src/async/countdown_timer.dart';

--- a/test/async/future_stream_test.dart
+++ b/test/async/future_stream_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.future_stream_test;
 
 import 'dart:async';

--- a/test/async/iteration_test.dart
+++ b/test/async/iteration_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.iteration_test;
 
 import 'dart:async';

--- a/test/async/metronome_test.dart
+++ b/test/async/metronome_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.time.clock_test;
 
 import 'package:quiver/src/async/metronome.dart';

--- a/test/async/stream_buffer_test.dart
+++ b/test/async/stream_buffer_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.stream_buffer_test;
 
 import 'dart:async';

--- a/test/async/stream_router_test.dart
+++ b/test/async/stream_router_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.async.stream_router_test;
 
 import 'dart:async';

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.cache.map_cache_test;
 
 import 'dart:async';

--- a/test/check_test.dart
+++ b/test/check_test.dart
@@ -32,7 +32,7 @@ void main() {
     });
 
     group('failure', () {
-      void checkArgumentShouldFail(Function f, [String/*?*/ expectedMessage]) {
+      void checkArgumentShouldFail(Function f, [String? expectedMessage]) {
         try {
           f();
           fail('Should have thrown an ArgumentError');
@@ -81,7 +81,7 @@ void main() {
     });
 
     group('failure', () {
-      void checkStateShouldFail(Function f, [String/*?*/ expectedMessage]) {
+      void checkStateShouldFail(Function f, [String? expectedMessage]) {
         expectedMessage ??= 'failed precondition';
         try {
           f();
@@ -126,7 +126,7 @@ void main() {
     });
 
     group('failure', () {
-      void checkNotNullShouldFail(Function f, [String/*?*/ expectedMessage]) {
+      void checkNotNullShouldFail(Function f, [String? expectedMessage]) {
         expectedMessage ??= 'null pointer';
         try {
           f();
@@ -175,7 +175,7 @@ void main() {
 
     group('failure', () {
       void checkListIndexShouldFail(int index, int size,
-          [message, String/*?*/ expectedMessage]) {
+          [message, String? expectedMessage]) {
         try {
           checkListIndex(index, size, message: message);
           fail('Should have thrown a RangeError');

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.bimap_test;
 
 import 'package:quiver/src/collection/bimap.dart';

--- a/test/collection/collection_test.dart
+++ b/test/collection/collection_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.collection_test;
 
 import 'package:quiver/collection.dart';

--- a/test/collection/delegates/iterable_test.dart
+++ b/test/collection/delegates/iterable_test.dart
@@ -28,7 +28,7 @@ class MyIterable extends DelegatingIterable<String> {
 
 void main() {
   group('DelegatingIterable', () {
-    /*late*/ DelegatingIterable<String> delegatingIterable;
+    late DelegatingIterable<String> delegatingIterable;
 
     setUp(() {
       delegatingIterable = MyIterable(['a', 'b', 'cc']);
@@ -69,7 +69,8 @@ void main() {
     });
 
     test('fold', () {
-      expect(delegatingIterable.fold('z', (p, e) => p + e), equals('zabcc'));
+      expect(delegatingIterable.fold('z', (String p, String e) => p + e),
+          equals('zabcc'));
     });
 
     test('forEach', () {
@@ -97,7 +98,6 @@ void main() {
 
     test('forEach', () {
       final it = delegatingIterable.iterator;
-      expect(it.current, isNull);
       expect(it.moveNext(), isTrue);
       expect(it.current, equals('a'));
       expect(it.moveNext(), isTrue);
@@ -105,7 +105,6 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals('cc'));
       expect(it.moveNext(), isFalse);
-      expect(it.current, isNull);
     });
 
     test('join', () {

--- a/test/collection/delegates/list_test.dart
+++ b/test/collection/delegates/list_test.dart
@@ -17,21 +17,21 @@ library quiver.collection.delegates.list_test;
 import 'package:quiver/src/collection/delegates/list.dart';
 import 'package:test/test.dart';
 
-class MyList extends DelegatingList<String> {
+class MyList<T> extends DelegatingList<T> {
   MyList(this._delegate);
 
-  final List<String> _delegate;
+  final List<T> _delegate;
 
   @override
-  List<String> get delegate => _delegate;
+  List<T> get delegate => _delegate;
 }
 
 void main() {
   group('DelegatingList', () {
-    /*late*/ DelegatingList<String> delegatingList;
+    late DelegatingList<String> delegatingList;
 
     setUp(() {
-      delegatingList = MyList(['a', 'b', 'cc']);
+      delegatingList = MyList<String>(['a', 'b', 'cc']);
     });
 
     test('[]', () {
@@ -71,8 +71,11 @@ void main() {
     });
 
     test('fillRange', () {
-      delegatingList.fillRange(0, 2);
-      expect(delegatingList, equals([null, null, 'cc']));
+      DelegatingList<String?> nullableDelegatingList =
+          MyList<String?>(['a', 'b', 'cc']);
+      nullableDelegatingList.fillRange(0, 2);
+      expect(nullableDelegatingList, equals([null, null, 'cc']));
+
       delegatingList.fillRange(0, 2, 'd');
       expect(delegatingList, equals(['d', 'd', 'cc']));
     });

--- a/test/collection/delegates/map_test.dart
+++ b/test/collection/delegates/map_test.dart
@@ -28,7 +28,7 @@ class MyMap extends DelegatingMap<String, int> {
 
 void main() {
   group('DelegatingMap', () {
-    /*late*/ DelegatingMap<String, int> delegatingMap;
+    late DelegatingMap<String, int> delegatingMap;
 
     setUp(() {
       delegatingMap = MyMap({'a': 1, 'bb': 2});

--- a/test/collection/delegates/queue_test.dart
+++ b/test/collection/delegates/queue_test.dart
@@ -30,7 +30,7 @@ class MyQueue extends DelegatingQueue<String> {
 
 void main() {
   group('DelegatingQueue', () {
-    /*late*/ DelegatingQueue<String> delegatingQueue;
+    late DelegatingQueue<String> delegatingQueue;
 
     setUp(() {
       delegatingQueue = MyQueue(Queue<String>.from(['a', 'b', 'cc']));

--- a/test/collection/delegates/set_test.dart
+++ b/test/collection/delegates/set_test.dart
@@ -30,7 +30,7 @@ class MySet extends DelegatingSet<String> {
 
 void main() {
   group('DelegatingSet', () {
-    /*late*/ DelegatingSet<String> delegatingSet;
+    late DelegatingSet<String> delegatingSet;
 
     setUp(() {
       delegatingSet = MySet(LinkedHashSet<String>.from(['a', 'b', 'cc']));

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.lru_map_test;
 
 import 'package:quiver/src/collection/lru_map.dart';

--- a/test/collection/multimap_test.dart
+++ b/test/collection/multimap_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.multimap_test;
 
 import 'package:quiver/src/collection/multimap.dart';

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// @dart = 2.9
+
 library quiver.collection.treeset_test;
 
 import 'package:quiver/src/collection/treeset.dart';

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -34,7 +34,7 @@ void main() {
     });
 
     test('ifPresent should execute only if present', () {
-      int value;
+      int? value;
       Optional<int>.of(7).ifPresent((v) {
         value = v;
       });
@@ -46,7 +46,7 @@ void main() {
     });
 
     test('isAbsent should execute only if absent', () {
-      int value;
+      int? value;
       Optional<int>.of(7).ifAbsent(() {
         value = 7;
       });

--- a/test/iterables/concat_test.dart
+++ b/test/iterables/concat_test.dart
@@ -40,21 +40,6 @@ void main() {
           [1, 2, 3, -1, -2, -3]);
     });
 
-    // TODO(cbracken): Delete post NNBD migration.
-    test('should throw for null input', () {
-      expect(() => concat(null), throwsNoSuchMethodError);
-    });
-
-    test('should throw if any input is null', () {
-      expect(
-          () => concat([
-                [1, 2],
-                null,
-                [3, 4]
-              ]).toList(),
-          throwsNoSuchMethodError);
-    });
-
     test('should reflect changes in the inputs', () {
       var a = [1, 2];
       var b = [4, 5];

--- a/test/iterables/generating_iterable_test.dart
+++ b/test/iterables/generating_iterable_test.dart
@@ -39,5 +39,5 @@ void main() {
 }
 
 class Node {
-  Node/*?*/ parent;
+  Node? parent;
 }

--- a/test/iterables/infinite_iterable_test.dart
+++ b/test/iterables/infinite_iterable_test.dart
@@ -35,7 +35,7 @@ class NaturalNumberIterator implements Iterator<int> {
 
 void main() {
   group('InfiniteIterable', () {
-    /*late*/ NaturalNumberIterable it;
+    late NaturalNumberIterable it;
 
     setUp(() {
       it = NaturalNumberIterable();

--- a/test/iterables/merge_test.dart
+++ b/test/iterables/merge_test.dart
@@ -59,15 +59,6 @@ void main() {
       expect(merge([<String>[], a]), ['a', 'b', 'c']);
     });
 
-    // TODO(cbracken): delete this after non-null by default migration.
-    test('should throw on null elements', () {
-      var a = ['a', null, 'c'];
-      var b = ['a', 'b', 'c'];
-      void nop(String s) {}
-      expect(() => merge([a, b]).forEach(nop), throwsNoSuchMethodError);
-      expect(() => merge([b, a]).forEach(nop), throwsNoSuchMethodError);
-    }, tags: ['fails-on-dartdevc', 'fails-on-dart2js']);
-
     test('should handle zig-zag case', () {
       var a = ['a', 'a', 'd', 'f'];
       var b = ['b', 'c', 'g', 'g'];
@@ -77,7 +68,7 @@ void main() {
     test('should handle max(a) < min(b) case', () {
       var a = <String>['a', 'b'];
       var b = <String>['c', 'd'];
-      expect(max(a)/*!*/.compareTo(min(b)/*!*/) < 0, isTrue); // test the test
+      expect(max(a)!.compareTo(min(b)!) < 0, isTrue); // test the test
       expect(merge([a, b]), ['a', 'b', 'c', 'd']);
     });
 

--- a/test/pattern/glob_test.dart
+++ b/test/pattern/glob_test.dart
@@ -59,7 +59,7 @@ void expectGlob(String pattern,
   for (final str in matches) {
     expect(glob.hasMatch(str), true);
     expect(glob.allMatches(str).map((m) => m.input), [str]);
-    Match match = glob.matchAsPrefix(str)/*!*/;
+    Match match = glob.matchAsPrefix(str)!;
     expect(match.start, 0);
     expect(match.end, str.length);
   }

--- a/test/strings_test.dart
+++ b/test/strings_test.dart
@@ -141,11 +141,6 @@ void main() {
       expect(loop('ab', 0, -6), 'bababa');
     });
 
-    // TODO(cbracken): Delete this test during NNBD migration.
-    test('should throw on null', () {
-      expect(() => loop(null, 6, 8), throwsArgumentError);
-    });
-
     // Corner cases
     test('should throw on empty', () {
       expect(() => loop('', 6, 8), throwsArgumentError);

--- a/test/testing/async/fake_async_test.dart
+++ b/test/testing/async/fake_async_test.dart
@@ -114,7 +114,7 @@ void main() {
 
         test('should call timers at their scheduled time', () {
           FakeAsync().run((async) {
-            DateTime/*?*/ calledAt;
+            DateTime? calledAt;
             var periodicCalledAt = <DateTime>[];
             Timer(elapseBy ~/ 2, () {
               calledAt = async.getClock(initialTime).now();
@@ -227,7 +227,7 @@ void main() {
 
         test('should pass the periodic timer itself to callbacks', () {
           FakeAsync().run((async) {
-            Timer/*?*/ passedTimer;
+            Timer? passedTimer;
             Timer periodic = Timer.periodic(elapseBy, (timer) {
               passedTimer = timer;
             });
@@ -238,7 +238,7 @@ void main() {
 
         test('should call microtasks before advancing time', () {
           FakeAsync().run((async) {
-            DateTime/*?*/ calledAt;
+            DateTime? calledAt;
             scheduleMicrotask(() {
               calledAt = async.getClock(initialTime).now();
             });
@@ -262,7 +262,7 @@ void main() {
         test('should increase negative duration timers to zero duration', () {
           FakeAsync().run((async) {
             var negativeDuration = const Duration(days: -1);
-            DateTime/*?*/ calledAt;
+            DateTime? calledAt;
             Timer(negativeDuration, () {
               calledAt = async.getClock(initialTime).now();
             });
@@ -317,7 +317,7 @@ void main() {
 
         test('should work with Future.delayed', () {
           FakeAsync().run((async) {
-            int/*?*/ result;
+            int? result;
             Future.delayed(elapseBy, () => result = 5);
             async.elapse(elapseBy);
             expect(result, 5);
@@ -327,7 +327,7 @@ void main() {
         test('should work with Future.timeout', () {
           FakeAsync().run((async) {
             var completer = Completer();
-            TimeoutException/*?*/ timeout;
+            TimeoutException? timeout;
             completer.future.timeout(elapseBy ~/ 2).catchError((err) {
               timeout = err;
             });
@@ -563,9 +563,9 @@ void main() {
       test('should report the number of pending microtasks', () {
         FakeAsync().run((async) {
           expect(async.microtaskCount, 0);
-          scheduleMicrotask(() => null);
+          scheduleMicrotask(() {});
           expect(async.microtaskCount, 1);
-          scheduleMicrotask(() => null);
+          scheduleMicrotask(() {});
           expect(async.microtaskCount, 2);
           async.flushMicrotasks();
           expect(async.microtaskCount, 0);
@@ -648,7 +648,7 @@ void main() {
         return FakeAsync().run((async) {
           var timeout = const Duration(minutes: 1);
           int counter = 0;
-          Timer/*?*/ timer;
+          late Timer timer;
           timer = Timer(timeout, () {
             counter++;
             expect(timer.isActive, isFalse,

--- a/test/testing/equality/equality_test.dart
+++ b/test/testing/equality/equality_test.dart
@@ -19,10 +19,10 @@ import 'package:test/test.dart';
 
 void main() {
   group('expectEquals', () {
-    /*late*/ _ValidTestObject reference;
-    /*late*/ _ValidTestObject equalObject1;
-    /*late*/ _ValidTestObject equalObject2;
-    /*late*/ _ValidTestObject notEqualObject1;
+    late _ValidTestObject reference;
+    late _ValidTestObject equalObject1;
+    late _ValidTestObject equalObject2;
+    late _ValidTestObject notEqualObject1;
 
     setUp(() {
       reference = _ValidTestObject(1, 2);

--- a/test/time/clock_test.dart
+++ b/test/time/clock_test.dart
@@ -25,7 +25,7 @@ void expectDate(DateTime date, int y, [int m = 1, int d = 1]) {
 
 void main() {
   group('clock', () {
-    Clock subject;
+    late Clock subject;
 
     setUp(() {
       subject = Clock.fixed(DateTime(2013));

--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -35,17 +35,17 @@ while (( "$#" )); do
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'
     echo -e 'dartanalyzer --fatal-warnings .'
-    dartanalyzer --lints --fatal-warnings --fatal-infos . || EXIT_CODE=$?
+    dartanalyzer --enable-experiment=non-nullable --lints --fatal-warnings --fatal-infos . || EXIT_CODE=$?
     ;;
   vm_test) echo
     echo -e '\033[1mTASK: vm_test\033[22m'
     echo -e 'pub run test -p vm'
-    pub run test -p vm -r expanded || EXIT_CODE=$?
+    pub run --enable-experiment=non-nullable test -p vm -r expanded || EXIT_CODE=$?
     ;;
   dart2js_test) echo
     echo -e '\033[1mTASK: dart2js_test\033[22m'
     echo -e 'pub run test -p chrome -x fails-on-dart2js'
-    pub run test -p chrome -x fails-on-dart2js -r expanded || EXIT_CODE=$?
+    pub run --enable-experiment=non-nullable test -p chrome -x fails-on-dart2js -r expanded || EXIT_CODE=$?
     ;;
   dartdevc_test) echo
     echo -e '\033[1mTASK: dartdevc_test\033[22m'


### PR DESCRIPTION
This applies non-null by default (NNBD) migration for files with hints.
All remaining non-migrated files are marked `// @dart = 2.9`.

Partial fix for #606.