### PR TITLE
Disallow nullable T in Optional<T>

### DIFF
--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -19,7 +19,7 @@ import 'dart:collection';
 /// Use Optional as an alternative to allowing fields, parameters or return
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
-class Optional<T> extends IterableBase<T> {
+class Optional<T extends Object> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;
 
@@ -27,9 +27,8 @@ class Optional<T> extends IterableBase<T> {
   ///
   /// Throws [ArgumentError] if [value] is null.
   Optional.of(T value) : _value = value {
-    // Disallow null even if an Optional<T?> is declared. This is most likely
-    // to happen accidentally if transform is inadvertently passed a function
-    // that returns a nullable type.
+    // TODO(cbracken): Delete and make this ctor const once mixed-mode
+    // execution is no longer around.
     ArgumentError.checkNotNull(value);
   }
 
@@ -87,7 +86,7 @@ class Optional<T> extends IterableBase<T> {
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// The transformer must not return [null]. If it does, an [ArgumentError] is thrown.
-  Optional<S> transform<S>(S transformer(T value)) {
+  Optional<S> transform<S extends Object>(S transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
         : Optional<S>.of(transformer(_value!));
@@ -98,7 +97,7 @@ class Optional<T> extends IterableBase<T> {
   /// If the Optional is [absent()], returns [absent()] without applying the transformer.
   ///
   /// Returns [absent()] if the transformer returns [null].
-  Optional<S> transformNullable<S>(S? transformer(T value)) {
+  Optional<S> transformNullable<S extends Object>(S? transformer(T value)) {
     return _value == null
         ? Optional<S>.absent()
         : Optional<S>.fromNullable(transformer(_value!));

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -64,17 +64,17 @@ void main() {
     });
 
     test('or should return present and replace absent', () {
-      expect(const Optional<int>.fromNullable(7).or(13), 7);
+      expect(Optional<int>.of(7).or(13), 7);
       expect(const Optional<int>.fromNullable(null).or(13), 13);
     });
 
     test('orNull should return value if present or null if absent', () {
-      expect(const Optional<int>.fromNullable(7).orNull, isNotNull);
+      expect(Optional<int>.of(7).orNull, isNotNull);
       expect(const Optional<int>.fromNullable(null).orNull, isNull);
     });
 
     test('transform should return transformed value or absent', () {
-      expect(const Optional<int>.fromNullable(7).transform((a) => a + 1),
+      expect(Optional<int>.of(7).transform((a) => a + 1),
           equals(Optional<int>.of(8)));
       expect(
           const Optional<int>.fromNullable(null)
@@ -83,15 +83,8 @@ void main() {
           isFalse);
     });
 
-    test('transform should throw ArgumentError if transformed value is null',
-        () {
-      expect(() => const Optional<int>.fromNullable(7).transform((_) => null),
-          throwsArgumentError);
-    });
-
     test('transformNullable should return transformed value or absent', () {
-      expect(
-          const Optional<int>.fromNullable(7).transformNullable((a) => a + 1),
+      expect(Optional<int>.of(7).transformNullable((a) => a + 1),
           equals(Optional<int>.of(8)));
       expect(
           const Optional<int>.fromNullable(null)
@@ -102,10 +95,9 @@ void main() {
 
     test('transformNullable should return absent if transformed value is null',
         () {
-      expect(
-          const Optional<int>.fromNullable(7)
-              .transformNullable((_) => null)
-              .isPresent,
+      String? maybeToString(int i) => null;
+
+      expect(Optional<int>.of(7).transformNullable(maybeToString).isPresent,
           isFalse);
     });
 


### PR DESCRIPTION
The entire point of Optional is to write null-safe code. This disallows
creation of Optionals of nullable types.

Partial fix for #606.