### PR TITLE
Migrate cache library to non-null by default

### DIFF
--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart = 2.9
-
 import 'dart:async';
 
 /// A function that produces a value for [key], for when a [Cache] needs to
@@ -25,18 +23,21 @@ typedef Loader<K, V> = FutureOr<V> Function(K key);
 
 /// A semi-persistent mapping of keys to values.
 ///
-/// All access to a Cache is asynchronous because many implementations will
-/// store their entries in remote systems, isolates, or otherwise have to do
-/// async IO to read and write.
+/// All access to a Cache is asynchronous because implementations may store
+/// their entries in remote systems, isolates, or otherwise have to do async IO
+/// to read and write.
 abstract class Cache<K, V> {
   /// Returns the value associated with [key].
-  Future<V> get(K key, {Loader<K, V> ifAbsent});
+  ///
+  /// If [ifAbsent] is specified and no value is associated with the key, a
+  /// mapping is added and the value is returned. Otherwise, returns null.
+  Future<V?> get(K key, {Loader<K, V> ifAbsent});
 
-  /// Sets the value associated with [key]. The Future completes with null when
-  /// the operation is complete.
-  Future<Null> set(K key, V value);
+  /// Sets the value associated with [key]. The Future completes when the
+  /// operation is complete.
+  Future<void> set(K key, V value);
 
-  /// Removes the value associated with [key]. The Future completes with null
-  /// when the operation is complete.
-  Future<Null> invalidate(K key);
+  /// Removes the value associated with [key]. The Future completes when the
+  /// operation is complete.
+  Future<void> invalidate(K key);
 }

--- a/lib/src/cache/map_cache.dart
+++ b/lib/src/cache/map_cache.dart
@@ -12,33 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart = 2.9
-
 import 'dart:async';
 import 'dart:collection';
 
-import 'package:quiver/collection.dart' show LruMap;
+import 'package:quiver/src/collection/lru_map.dart' show LruMap;
 
 import 'cache.dart';
 
 /// A [Cache] that's backed by a [Map].
 class MapCache<K, V> implements Cache<K, V> {
   /// Creates a new [MapCache], optionally using [map] as the backing [Map].
-  MapCache({Map<K, V> map}) : _map = map ?? HashMap<K, V>();
+  MapCache({Map<K, V>? map}) : _map = map ?? HashMap<K, V>();
 
   /// Creates a new [MapCache], using [LruMap] as the backing [Map].
-  /// Optionally specify [maximumSize].
-  factory MapCache.lru({int maximumSize}) {
+  ///
+  /// When [maximumSize] is specified, the cache is limited to the specified
+  /// number of pairs, otherwise it is limited to 100.
+  factory MapCache.lru({int? maximumSize}) {
+    // TODO(cbracken): inline the default value here for readability.
+    // https://github.com/google/quiver-dart/issues/653
     return MapCache<K, V>(map: LruMap(maximumSize: maximumSize));
   }
 
   final Map<K, V> _map;
 
-  /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the same key.
+  /// Map of outstanding ifAbsent calls used to prevent concurrent loads of the
+  /// same key.
   final _outstanding = <K, FutureOr<V>>{};
 
   @override
-  Future<V> get(K key, {Loader<K, V> ifAbsent}) async {
+  Future<V?> get(K key, {Loader<K, V>? ifAbsent}) async {
     if (_map.containsKey(key)) {
       return _map[key];
     }
@@ -64,12 +67,12 @@ class MapCache<K, V> implements Cache<K, V> {
   }
 
   @override
-  Future<Null> set(K key, V value) async {
+  Future<void> set(K key, V value) async {
     _map[key] = value;
   }
 
   @override
-  Future<Null> invalidate(K key) async {
+  Future<void> invalidate(K key) async {
     _map.remove(key);
   }
 }

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart = 2.9
-
 library quiver.cache.map_cache_test;
 
 import 'dart:async';
@@ -23,7 +21,7 @@ import 'package:test/test.dart';
 
 void main() {
   group('MapCache', () {
-    /*late*/ MapCache<String, String> cache;
+    late MapCache<String, String> cache;
 
     setUp(() {
       cache = MapCache<String, String>();

--- a/test/collection/lru_map_test.dart
+++ b/test/collection/lru_map_test.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// @dart = 2.9
-
 library quiver.collection.lru_map_test;
 
 import 'package:quiver/src/collection/lru_map.dart';
@@ -21,8 +19,8 @@ import 'package:test/test.dart';
 
 void main() {
   group('LruMap', () {
-    /// A map that will be initialize by individual tests.
-    /*late*/ LruMap<String, String> lruMap;
+    /// A map that will be initialized by individual tests.
+    late LruMap<String, String> lruMap;
 
     test('the length property reflects how many keys are in the map', () {
       lruMap = LruMap();
@@ -319,7 +317,7 @@ void main() {
   });
 
   group('LruMap builds an informative string representation', () {
-    /*late*/ LruMap<String, dynamic> lruMap;
+    late LruMap<String, dynamic> lruMap;
 
     setUp(() {
       lruMap = LruMap();


### PR DESCRIPTION
This is stacked on top of https://github.com/google/quiver-dart/pull/651. Only the second commit should be reviewed.

Partial fix for #606.