### PR TITLE
Re-enable dartfmt post null-safety migration

### DIFF
--- a/lib/src/collection/multimap.dart
+++ b/lib/src/collection/multimap.dart
@@ -135,7 +135,8 @@ abstract class _BaseMultimap<K, V, C extends Iterable<V>>
   @override
   bool containsKey(Object? key) => _map.keys.contains(key);
   @override
-  bool contains(Object? key, Object? value) => _map[key]?.contains(value) == true;
+  bool contains(Object? key, Object? value) =>
+      _map[key]?.contains(value) == true;
 
   @override
   Iterable<V> operator [](Object? key) {

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -124,7 +124,8 @@ abstract class _TreeNode<V> {
     if (node.hasRight) {
       return node.right.minimumNode;
     }
-    while (node.hasParent && node.parent.hasRight && node == node.parent.right) {
+    while (
+        node.hasParent && node.parent.hasRight && node == node.parent.right) {
       node = node.parent;
     }
     return node.hasParent ? node.parent : null;
@@ -151,7 +152,8 @@ abstract class _TreeNode<V> {
 ///           Ronald L. Rivest, Clifford Stein.
 ///        chapter 13.2
 class AvlTreeSet<V> extends TreeSet<V> {
-  AvlTreeSet({Comparator<V> comparator = _defaultCompare}) : super._(comparator);
+  AvlTreeSet({Comparator<V> comparator = _defaultCompare})
+      : super._(comparator);
 
   int _length = 0;
   AvlNode<V>? _root;
@@ -721,7 +723,8 @@ class AvlTreeSet<V> extends TreeSet<V> {
     // Default: nearest absolute value
     // Fell off the tree looking for the exact match; now we need
     // to find the nearest element.
-    x = (compare < 0 ? previous.predecessor : previous.successor) as AvlNode<V>?;
+    x = (compare < 0 ? previous.predecessor : previous.successor)
+        as AvlNode<V>?;
     if (x == null) {
       return previous;
     }

--- a/lib/src/iterables/merge.dart
+++ b/lib/src/iterables/merge.dart
@@ -24,7 +24,8 @@ import 'dart:collection';
 ///
 /// If any of the [iterables] contain null elements, an exception will be
 /// thrown.
-Iterable<T> merge<T>(Iterable<Iterable<T>> iterables, [Comparator<T>? compare]) {
+Iterable<T> merge<T>(Iterable<Iterable<T>> iterables,
+    [Comparator<T>? compare]) {
   if (iterables.isEmpty) return <T>[];
   if (iterables.every((i) => i.isEmpty)) return <T>[];
   return _Merge<T>(iterables, compare ?? _compareAny);

--- a/lib/testing/src/equality/equality.dart
+++ b/lib/testing/src/equality/equality.dart
@@ -77,7 +77,8 @@ class _EqualityGroupMatcher extends Matcher {
           Map matchState, bool verbose) =>
       mismatchDescription.add(' ${matchState[failureReason]}');
 
-  void _verifyEqualityGroups(Map<String?, List?>? equalityGroups, Map matchState) {
+  void _verifyEqualityGroups(
+      Map<String?, List?>? equalityGroups, Map matchState) {
     if (equalityGroups == null) {
       throw MatchError('Equality Group must not be null');
     }

--- a/test/async/collect_test.dart
+++ b/test/async/collect_test.dart
@@ -31,9 +31,11 @@ void main() {
       var events = [];
       var done = Completer<List<dynamic>>();
 
-      collect(futures).listen(events.add, onError: (i) {
-        events.add('e$i');
-      }, onDone: () =>  done.complete([]));
+      collect(futures).listen(events.add,
+          onError: (i) {
+            events.add('e$i');
+          },
+          onDone: () => done.complete([]));
       return Future.wait(futures).catchError((_) => done.future).then((_) {
         expect(events, [0, 'e1', 2, 'e3', 4]);
       });

--- a/test/async/stream_buffer_test.dart
+++ b/test/async/stream_buffer_test.dart
@@ -88,7 +88,9 @@ void main() {
     test('underflows when asked to', () async {
       StreamBuffer<int> buf = StreamBuffer(throwOnError: true);
       Future<List<int>> futureBytes = buf.read(4);
-      Stream.fromIterable([[1, 2, 3]]).pipe(buf);
+      Stream.fromIterable([
+        [1, 2, 3]
+      ]).pipe(buf);
       try {
         List<int> bytes = await futureBytes;
         fail('should not have gotten bytes: $bytes');

--- a/test/collection/bimap_test.dart
+++ b/test/collection/bimap_test.dart
@@ -136,7 +136,8 @@ void main() {
       expect(map.inverse.containsValue(k2), false);
     });
 
-    test('should throw on overwriting unmapped keys with a mapped null value', () {
+    test('should throw on overwriting unmapped keys with a mapped null value',
+        () {
       final map = BiMap<String, int?>();
       map[k1] = null;
       expect(() => map[k2] = null, throwsArgumentError);

--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -28,9 +28,7 @@ while (( "$#" )); do
   dartfmt) echo
     echo -e '\033[1mTASK: dartfmt\033[22m'
     echo -e 'dartfmt -n --set-exit-if-changed .'
-    # TODO(cbracken): Re-enable when build_packages have NNBD releases.
-    # https://github.com/google/quiver-dart/issues/634
-    #dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
+    dartfmt -n --set-exit-if-changed . || EXIT_CODE=$?
     ;;
   dartanalyzer) echo
     echo -e '\033[1mTASK: dartanalyzer\033[22m'


### PR DESCRIPTION
This had been disabled to reduce churn while we added migration hint
comments prior to applying them.

This is cleanup after #606.