### PR TITLE
Revert Optional<T extends Object> to Optional<T>

### DIFF
--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -19,7 +19,10 @@ import 'dart:collection';
 /// Use Optional as an alternative to allowing fields, parameters or return
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
-class Optional<T extends Object> extends IterableBase<T> {
+//
+// TODO(cbracken): Consider making this Optional<T extends Object>.
+// See: https://github.com/google/quiver-dart/issues/666
+class Optional<T> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;
 


### PR DESCRIPTION
Optional is intended as a substitute for non-nullable values. Ideally,
it should have a generic type of `T extends Object` in order to prevent
non-sensical declarations like `Optional<Foo?>`. Such declarations are
unlikely to happen intentionally, but one could imagine the case of an
Optional<T> used in another generic class, where T is a nullable type.

In #652, we prevented such uses by declaring Optional as
Optional<T extends Object>.

This turns out to be a significant breaking change, since previously, T
implicitly extended `dynamic` and therefore checks like the following
didn't produce any analysis errors:

    if (obj is Optional) {
      return obj.value.someMethod();
    }

where `someMethod` is a method defined on `T`.

A survey of the Google codebase suggests this would be a fairly
extensive breaking change. Given that Optional makes little sense once
null-safety is enabled in the language by default, the simpler change
may simply be to leave as-is and deprecate the class once null-safety
lands in the language.

It appears that there are no checks on the return type of `transform`,
and this seems significantly unlikely, therefore we leave that change in
place.

This partially reverts 28301f9551e87bd3fbc3c17820fdb4dba12619b8.

Related: https://github.com/google/quiver-dart/issues/666
Related: #606