### PR TITLE
Allow null args to lists/maps/setsEqual

### DIFF
--- a/lib/src/collection/utils.dart
+++ b/lib/src/collection/utils.dart
@@ -17,8 +17,9 @@
 /// Returns `true` if [a] and [b] are both null, or they are the same length
 /// and every element of [a] is equal to the corresponding element at the same
 /// index in [b].
-bool listsEqual(List a, List b) {
+bool listsEqual(List? a, List? b) {
   if (a == b) return true;
+  if (a == null || b == null) return false;
   if (a.length != b.length) return false;
 
   for (int i = 0; i < a.length; i++) {
@@ -32,8 +33,9 @@ bool listsEqual(List a, List b) {
 ///
 /// Returns `true` if [a] and [b] are both null, or they are the same length
 /// and every key `k` in [a] exists in [b] and the values `a[k] == b[k]`.
-bool mapsEqual(Map a, Map b) {
+bool mapsEqual(Map? a, Map? b) {
   if (a == b) return true;
+  if (a == null || b == null) return false;
   if (a.length != b.length) return false;
 
   for (final k in a.keys) {
@@ -49,8 +51,9 @@ bool mapsEqual(Map a, Map b) {
 ///
 /// Returns `true` if [a] and [b] are both null, or they are the same length and
 /// every element in [b] exists in [a].
-bool setsEqual(Set a, Set b) {
+bool setsEqual(Set? a, Set? b) {
   if (a == b) return true;
+  if (a == null || b == null) return false;
   if (a.length != b.length) return false;
 
   return a.containsAll(b);

--- a/test/collection/utils_test.dart
+++ b/test/collection/utils_test.dart
@@ -20,12 +20,15 @@ import 'package:test/test.dart';
 void main() {
   group('listsEqual', () {
     test('return true for equal lists', () {
+      expect(listsEqual(null, null), isTrue);
       expect(listsEqual([], []), isTrue);
       expect(listsEqual([1], [1]), isTrue);
       expect(listsEqual(['a', 'b'], ['a', 'b']), isTrue);
     });
 
     test('return false for unequal lists', () {
+      expect(listsEqual(null, []), isFalse);
+      expect(listsEqual([], null), isFalse);
       expect(listsEqual([1], [2]), isFalse);
       expect(listsEqual([1], []), isFalse);
       expect(listsEqual([], [1]), isFalse);


### PR DESCRIPTION
This updates the parameters to listsEqual, mapsEqual and setsEqual in
the collection utils library to nullable types.

This avoids forcing callers to manually check for null, is a bit more in
line with Object.equals() which handles the null check in the runtime,
and avoids a breaking change to users who have not yet transitioned to
non-null by default.

Related: #606.