### PR TITLE
Eliminate dependency on package:meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.0-nullsafety.3
+
+  * Eliminate dependency on package:meta.
+
 #### 3.0.0-nullsafety.2 - 2020-11-05
 
   * BREAKING CHANGE: This version requires Dart SDK 2.12.0-0 or later.

--- a/lib/collection.dart
+++ b/lib/collection.dart
@@ -23,5 +23,5 @@ export 'src/collection/delegates/queue.dart';
 export 'src/collection/delegates/set.dart';
 export 'src/collection/lru_map.dart';
 export 'src/collection/multimap.dart';
-export 'src/collection/treeset.dart';
+export 'src/collection/treeset.dart' hide debugGetNode, AvlNode;
 export 'src/collection/utils.dart';

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -14,8 +14,6 @@
 
 import 'dart:collection';
 
-import 'package:meta/meta.dart' show visibleForTesting;
-
 int _defaultCompare(a, b) {
   return a.compareTo(b);
 }
@@ -878,9 +876,10 @@ class AvlTreeSet<V> extends TreeSet<V> {
     }
     return set;
   }
+}
 
-  @visibleForTesting
-  AvlNode<V>? getNode(V object) => _getNode(object);
+AvlNode<V>? debugGetNode<V>(AvlTreeSet<V> treeset, V object) {
+  return treeset._getNode(object);
 }
 
 typedef _IteratorMove = bool Function();
@@ -1010,7 +1009,6 @@ class _AvlTreeIterator<V> implements BidirectionalIterator<V> {
 }
 
 /// Private class used to track element insertions in the [TreeSet].
-@visibleForTesting
 class AvlNode<V> extends _TreeNode<V> {
   AvlNode({required V object}) : super(object: object);
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,12 +3,11 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 homepage: https://github.com/google/quiver-dart
-version: 3.0.0-nullsafety.2
+version: 3.0.0-nullsafety.3
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 dependencies:
   matcher: ^0.12.10-nullsafety.3
-  meta: ^1.3.0-nullsafety.6
 dev_dependencies:
   path: ^1.8.0-nullsafety.3
   test: ^1.16.0-nullsafety.8

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -55,9 +55,9 @@ void main() {
         expect(tree.lookup(20), equals(20), reason: 'missing 20');
       });
       test('order is correct', () {
-        AvlNode ten = tree.getNode(10)!;
-        AvlNode twenty = tree.getNode(20)!;
-        AvlNode fifteen = tree.getNode(15)!;
+        AvlNode ten = debugGetNode(tree, 10)!;
+        AvlNode twenty = debugGetNode(tree, 20)!;
+        AvlNode fifteen = debugGetNode(tree, 15)!;
         expect(ten.predecessor, isNull, reason: '10 is the smalled element');
         expect(ten.successor, equals(fifteen), reason: '15 should follow 10');
         expect(ten.successor!.successor, equals(twenty),
@@ -422,9 +422,9 @@ void main() {
         tree.add(20);
         tree.add(15);
 
-        AvlNode ten = tree.getNode(10)!;
-        AvlNode twenty = tree.getNode(20)!;
-        AvlNode fifteen = tree.getNode(15)!;
+        AvlNode ten = debugGetNode(tree, 10)!;
+        AvlNode twenty = debugGetNode(tree, 20)!;
+        AvlNode fifteen = debugGetNode(tree, 15)!;
 
         expect(ten.parent, equals(fifteen));
         expect(ten.hasLeft, isFalse);
@@ -447,9 +447,9 @@ void main() {
         tree.add(10);
         tree.add(20);
 
-        AvlNode thirty = tree.getNode(30)!;
-        AvlNode ten = tree.getNode(10)!;
-        AvlNode twenty = tree.getNode(20)!;
+        AvlNode thirty = debugGetNode(tree, 30)!;
+        AvlNode ten = debugGetNode(tree, 10)!;
+        AvlNode twenty = debugGetNode(tree, 20)!;
 
         expect(thirty.parent, equals(twenty));
         expect(thirty.hasLeft, isFalse);
@@ -473,9 +473,9 @@ void main() {
         tree.add(2);
         tree.add(3);
 
-        AvlNode one = tree.getNode(1)!;
-        AvlNode two = tree.getNode(2)!;
-        AvlNode three = tree.getNode(3)!;
+        AvlNode one = debugGetNode(tree, 1)!;
+        AvlNode two = debugGetNode(tree, 2)!;
+        AvlNode three = debugGetNode(tree, 3)!;
 
         expect(one.parent, equals(two));
         expect(one.hasLeft, isFalse);
@@ -499,9 +499,9 @@ void main() {
         tree.add(2);
         tree.add(1);
 
-        AvlNode one = tree.getNode(1)!;
-        AvlNode two = tree.getNode(2)!;
-        AvlNode three = tree.getNode(3)!;
+        AvlNode one = debugGetNode(tree, 1)!;
+        AvlNode two = debugGetNode(tree, 2)!;
+        AvlNode three = debugGetNode(tree, 3)!;
 
         expect(one.parent, equals(two));
         expect(one.hasLeft, isFalse);


### PR DESCRIPTION
This eliminates the dependency on package:meta, which was previously only used for `@required` and `@visibleForTesting`. 

`@required` was eliminated with the transition to non-null by default.

`@visibleForTesting` was eliminated by replacing `AvlTree.getNode(object)` with `debugGetNode(AvlTree, object)` and hiding it and `AvlNode` in the top-level re-export in the collection library.