### PR TITLE
Deprecate Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 #### 3.2.0-dev
 
+  * Deprecate `Optional`. With the introduction of non-null by default in Dart
+    SDK 2.12, existing users should migrate to non-nullable types. This type
+    will be removed in Quiver 4.0.0.
   * Expose `TreeIterator` for iterating `TreeSet` instead of using
     `BidirectionalIterator`.
   * Require Dart 2.17

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -24,7 +24,9 @@ import 'dart:collection';
 ///
 /// With the introduction of non-null by default in Dart SDK 2.12, developers
 /// should avoid adding more uses of this type. Existing users should migrate
-/// away from the `Optional` type to types marked nullable: `T?`.
+/// away from the `Optional` type to types marked nullable: `T?`. This type
+/// will be removed in Quiver 4.0.0.
+@Deprecated('Migrate to a non-nullable type. Will be removed in 4.0.0')
 class Optional<T> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;

--- a/test/core/optional_test.dart
+++ b/test/core/optional_test.dart
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: deprecated_member_use_from_same_package
 library quiver.core.optional_test;
 
 import 'package:quiver/src/core/optional.dart';


### PR DESCRIPTION
With the introduction of non-null by default in Dart SDK 2.12, existing
users should migrate to non-nullable types. This type will be removed in
Quiver 4.0.0.

See: #666 