### PR TITLE
Make a StreamRouter's route remove itself when all listener cancel

### DIFF
--- a/lib/src/async/stream_router.dart
+++ b/lib/src/async/stream_router.dart
@@ -47,8 +47,12 @@ class StreamRouter<T> {
   /// Events that match [predicate] are sent to the stream created by this
   /// method, and not sent to any other router streams.
   Stream<T> route(bool predicate(T event)) {
-    var controller = StreamController<T>.broadcast();
-    _routes.add(_Route(predicate, controller));
+    _Route route;
+    var controller = StreamController<T>.broadcast(onCancel: () {
+      _routes.remove(route);
+    });
+    route = _Route(predicate, controller);
+    _routes.add(route);
     return controller.stream;
   }
 


### PR DESCRIPTION
In my [dart library][1] where we use StreamRouter, some weird bug was exhibited where a channel being previously listened for, then cancelled, then re-listened would get messages on the second listening.

That was because, basically, if you don't reuse the initial stream you got the first time you called `StreamRouter().route(...)`, subsequent equivalent routing would never receive events from the stream router. That's expected, unless you cancel all listeners from the initial stream. 

With this PR, once all listeners to the stream have cancelled, the corresponding route is closed and removed from the stream router. This also has the benefit that a stream router now automatically scales down with the amount of stream listened to. 