### PR TITLE
Remove unused dart:async imports

### DIFF
--- a/lib/src/async/collect.dart
+++ b/lib/src/async/collect.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 /// Returns a stream of completion events for the input [futures].
 ///
 /// Successfully completed futures yield data events, while futures completed

--- a/lib/src/async/enumerate.dart
+++ b/lib/src/async/enumerate.dart
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async';
-
 import 'package:quiver/iterables.dart' show IndexedValue;
 
 /// Returns a [Stream] of [IndexedValue]s where the nth value holds the nth

--- a/lib/src/async/string.dart
+++ b/lib/src/async/string.dart
@@ -12,7 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import 'dart:async' show Stream;
 import 'dart:convert' show Encoding, utf8;
 
 ///  Converts a [Stream] of byte lists to a [String].

--- a/test/async/stream_buffer_test.dart
+++ b/test/async/stream_buffer_test.dart
@@ -14,8 +14,6 @@
 
 library quiver.async.stream_buffer_test;
 
-import 'dart:async';
-
 import 'package:quiver/src/async/stream_buffer.dart';
 import 'package:test/test.dart';
 


### PR DESCRIPTION
As of Dart 2.1, Future/Stream have been exported from dart:core.