### PR TITLE
Fix error when AVLTree root element is removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+#### 3.0.1-dev
+
+  * Fix: Eliminate null check error on removal of root node of
+    `AVLTree`.
+
 #### 3.0.0 - 2021-02-16
 
   * BREAKING CHANGE: This version requires Dart SDK 2.12.0 or later.

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -498,7 +498,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
       y.right._parent = y;
       y._balanceFactor = node._balanceFactor;
 
-      y._parent = node.parent;
+      y._parent = node._parent;
       if (_root == node) {
         _root = y;
       } else if (node.parent._left == node) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 repository: https://github.com/google/quiver-dart
-version: 3.0.0
+version: 3.0.1-dev
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'

--- a/test/collection/treeset_test.dart
+++ b/test/collection/treeset_test.dart
@@ -340,6 +340,13 @@ void main() {
         expect(tree.toList(), equals([15, 21]));
       });
 
+      test('remove root', () {
+        tree = TreeSet()
+          ..addAll([1, 3, 5, 6, 2, 4])
+          ..removeAll([1, 3]);
+        expect(tree.toList(), equals([2, 4, 5, 6]));
+      });
+
       test('removeAll from tree', () {
         tree = TreeSet()..addAll([10, 20, 15, 21, 30, 20]);
         tree.removeAll([42]);


### PR DESCRIPTION
When removing the root element of an AVLTree, the parent is null. The
getter applies the ! operator to node._parent. Instead we reference the
member directly.