### PR TITLE
Eliminate unnecessary null check in partition

### DIFF
--- a/lib/src/iterables/partition.dart
+++ b/lib/src/iterables/partition.dart
@@ -41,10 +41,6 @@ class _PartitionIterator<T> implements Iterator<List<T>> {
 
   @override
   List<T> get current {
-    // TODO(cbracken): remove post NNBD migration.
-    if (_current == null) {
-      throw StateError('Must call moveNext before current');
-    }
     return _current as List<T>;
   }
 

--- a/test/iterables/partition_test.dart
+++ b/test/iterables/partition_test.dart
@@ -33,7 +33,7 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([1, 2, 3]));
       expect(it.moveNext(), isFalse);
-      expect(() => it.current, throwsStateError);
+      expect(() => it.current, throwsError);
     });
 
     test('should return one partition if partition size == input size', () {
@@ -41,7 +41,7 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([1, 2, 3, 4, 5]));
       expect(it.moveNext(), isFalse);
-      expect(() => it.current, throwsStateError);
+      expect(() => it.current, throwsError);
     });
 
     test(
@@ -53,7 +53,9 @@ void main() {
       expect(it.moveNext(), isTrue);
       expect(it.current, equals([4, 5]));
       expect(it.moveNext(), isFalse);
-      expect(() => it.current, throwsStateError);
+      expect(() => it.current, throwsError);
     });
   });
 }
+
+final throwsError = throwsA(const TypeMatcher<Error>());


### PR DESCRIPTION
Now that NNDB migration is complete, these checks are no longer
necessary. Users who explicitly opt out of null safety will get null if
they call `current` prior to `moveNext`.

This was missed at the end of NNBD migration due to a slight
mismatch in the TODO format when compared to the others.

Fixes https://github.com/google/quiver-dart/issues/612