### PR TITLE
Version 3.0.1+1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 3.0.1+1 - 2021-10-14
+
+  * Add documentation to `Optional` suggesting that adding new uses be avoided
+    and existing uses should be migrated to nullable types in codebases where
+    non-null by default has been enabled.
+
 #### 3.0.1 - 2021-04-06
 
   * Fix: Eliminate null check error on removal of root node of

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -19,9 +19,10 @@ import 'dart:collection';
 /// Use Optional as an alternative to allowing fields, parameters or return
 /// values to be null. It signals that a value is not required and provides
 /// convenience methods for dealing with the absent case.
-//
-// TODO(cbracken): Consider making this Optional<T extends Object>.
-// See: https://github.com/google/quiver-dart/issues/666
+///
+/// With the introduction of non-null by default in Dart SDK 2.12, developers
+/// should avoid adding more uses of this type. Existing users should migrate
+/// away from the `Optional` type to types marked nullable: `T?`.
 class Optional<T> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 repository: https://github.com/google/quiver-dart
-version: 3.0.1
+version: 3.0.1+1
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
This version adds a minor documentation change.

With non-null by default implemented as of Dart 2.12, developers should
avoid adding more uses of the Optional type in there code, and ideally
start migrating existing uses to nullable types.

Not marking this as deprecated yet, since not all users have migrated
their codebases to NNBD, and migration off this type has some tricky
edge-cases.

Related: #679
Related: #672 (deprecate optional)