### PR TITLE
Re-enable dartdevc_test

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,9 +14,9 @@ dependencies:
 dev_dependencies:
   path: ^1.8.0
   test: ^1.16.0
-#DDC_TEST:  build_runner: ^1.3.1
-#DDC_TEST:  build_test: ^0.10.6
-#DDC_TEST:  build_web_compilers: ^2.0.0
+#DDC_TEST:  build_runner: ^2.1.4
+#DDC_TEST:  build_test: ^2.1.4
+#DDC_TEST:  build_web_compilers: ^3.2.1
 
 # The above dependencies are used for running the dartdevc_test task on Travis.
 # Since build_runner indirectly depends on quiver, we patch these in at test

--- a/tool/travis/task.sh
+++ b/tool/travis/task.sh
@@ -47,10 +47,7 @@ while (( "$#" )); do
     ;;
   dartdevc_test) echo
     echo -e '\033[1mTASK: dartdevc_test\033[22m'
-    echo -e '*** TEMPORARILY DISABLED ON null_safety branch pending migration on build_* packages'
-    # TODO(cbracken): Re-enable when build_packages have NNBD releases.
-    # https://github.com/google/quiver-dart/issues/619
-    #./tool/travis/ddc_test.sh -p chrome -x fails-on-dartdevc -r expanded || EXIT_CODE=$?
+    ./tool/travis/ddc_test.sh -p chrome -x fails-on-dartdevc -r expanded || EXIT_CODE=$?
     ;;
   *) echo -e "\033[31mUnknown task: '${TASK}'. Error!\033[0m"
     EXIT_CODE=1


### PR DESCRIPTION
The build_packages have NNBD releases such as:
build_runner 2.1.4 is null safety https://pub.dev/packages/build_runner/versions/2.1.4
build_test 2.1.4 is null safety https://pub.dev/packages/build_test/versions/2.1.4
build_web_compilers 3.2.1 is null safety https://pub.dev/packages/build_web_compilers/versions/3.2.1