### PR TITLE
Remove broken references to the defunct mirrors library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.0.1+2 - 2022-03-09
+
+  * Remove broken references to the defunct mirrors library.
+
 #### 3.0.1+1 - 2021-10-14
 
   * Add documentation to `Optional` suggesting that adding new uses be avoided

--- a/README.md
+++ b/README.md
@@ -115,23 +115,6 @@ require a finite length.
 
 [quiver.iterables]: https://pub.dev/documentation/quiver/latest/quiver.iterables/quiver.iterables-library.html
 
-## [quiver.mirrors][]
-
-`getTypeName` returns the name of a Type instance.
-
-`implements` and `classImplements` determine if an instance or ClassMirror,
-respectively, implement the interface represented by a Type instance. They
-implement the behavior of `is` for mirrors, except for generics.
-
-`getMemberMirror` searches though a ClassMirror and its class hierarchy for
-a member. This makes up for the fact that `ClassMirror.members` doesn't
-contain members from interfaces or superclasses.
-
-`Method` wraps an InstanceMirror and Symbol to create a callable that invokes
-a method on the instance. It in effect closurizes a method reflectively.
-
-[quiver.mirrors]: https://pub.dev/documentation/quiver/latest/quiver.mirrors/quiver.mirrors-library.html
-
 ## [quiver.pattern][]
 
 pattern.dart container utilities for work with `Pattern`s and `RegExp`s.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 repository: https://github.com/google/quiver-dart
-version: 3.0.1+1
+version: 3.0.1+2
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'


### PR DESCRIPTION
The quiver README.md file still referred to mirrors library, which no longer exists.