### PR TITLE
Re-enable CI using GitHub Actions

### DIFF
--- a/.github/workflows/dart.yml
+++ b/.github/workflows/dart.yml
@@ -1,0 +1,61 @@
+name: Dart CI
+
+on:
+  # Run on PRs and pushes to the default branch.
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: "0 0 * * 0"
+
+env:
+  PUB_ENVIRONMENT: bot.github
+
+jobs:
+  # Check code formatting and static analysis on a single OS (linux)
+  # against Dart dev.
+  analyze:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk: [dev]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: ${{ matrix.sdk }}
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Check formatting
+        run: dart format --output=none --set-exit-if-changed .
+        if: always() && steps.install.outcome == 'success'
+      - name: Analyze code
+        run: dart analyze --fatal-infos
+        if: always() && steps.install.outcome == 'success'
+
+  # Run tests on a matrix consisting of two dimensions:
+  # 1. OS: ubuntu-latest, (macos-latest, windows-latest)
+  # 2. release channel: dev
+  test:
+    needs: analyze
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test against the SDK lower-bound defined in pubspec.yaml and dev.
+        os: [ubuntu-latest]
+        sdk: [2.12.0, dev]
+    steps:
+      - uses: actions/checkout@v2
+      - uses: dart-lang/setup-dart@v1.0
+        with:
+          sdk: ${{ matrix.sdk }}
+      - id: install
+        name: Install dependencies
+        run: dart pub get
+      - name: Run VM tests
+        run: dart test --platform vm
+        if: always() && steps.install.outcome == 'success'

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,8 @@ description: >-
 repository: https://github.com/google/quiver-dart
 version: 3.0.1+2
 
+# When updating SDK lower bound, also update .github/workflows/dart.yml to test
+# against the new lower bound.
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
 


### PR DESCRIPTION
Travis CI was disabled for all Google projects due to permissioning
requirement changes in the move from travis-ci.org to travis-ci.com.
This re-enables VM-based testing for Quiver.

We'll still want to re-enable web testing under both dart2js and
dartdevc in the future, but this is a good start.

Issue: https://github.com/google/quiver-dart/issues/613