### PR TITLE
Remove deprecated non-nullable analysis option

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,4 @@
 analyzer:
-  enable-experiment:
-    - non-nullable
   errors:
     # treat missing required parameters as a warning (not a hint)
     missing_required_param: warning


### PR DESCRIPTION
This is now the default and no longer required.