### PR TITLE
Make Cache.get ifAbsent param nullable

### DIFF
--- a/lib/src/cache/cache.dart
+++ b/lib/src/cache/cache.dart
@@ -31,7 +31,7 @@ abstract class Cache<K, V> {
   ///
   /// If [ifAbsent] is specified and no value is associated with the key, a
   /// mapping is added and the value is returned. Otherwise, returns null.
-  Future<V?> get(K key, {Loader<K, V> ifAbsent});
+  Future<V?> get(K key, {Loader<K, V>? ifAbsent});
 
   /// Sets the value associated with [key]. The Future completes when the
   /// operation is complete.

--- a/test/cache/map_cache_test.dart
+++ b/test/cache/map_cache_test.dart
@@ -52,6 +52,12 @@ void main() {
       });
     });
 
+    test('should return null if no value and no ifAbsent handler', () {
+      return cache.get('foo').then((value) {
+        expect(value, isNull);
+      });
+    });
+
     test('should load a value given a synchronous loader', () {
       return cache.get('foo', ifAbsent: (k) => k + k).then((value) {
         expect(value, 'foofoo');


### PR DESCRIPTION
During non-null by default migration, Cache.get's ifAbsent parameter was
incorrectly marked non-nullable. The parameter is optional and the doc
comment clearly states that ifAbsent is not required.

Reported internally at Google by Yutong Jin.

Issue: https://github.com/google/quiver-dart/issues/693