### PR TITLE
Stop exposing `BidirectionalIterator`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
   * Expose `TreeIterator` for iterating `TreeSet` instead of using
     `BidirectionalIterator`.
+
 #### 3.1.0 - 2022-05-03
 
   * Fix: Make Cache.get ifAbsent parameter nullable. The parameter was always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#### 3.2.0
+
+  * Expose `TreeIterator` for iterating `TreeSet` instead of using
+    `BidirectionalIterator`.
 #### 3.1.0 - 2022-05-03
 
   * Fix: Make Cache.get ifAbsent parameter nullable. The parameter was always

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -40,11 +40,11 @@ abstract class TreeSet<V> extends IterableBase<V> implements Set<V> {
   @override
   bool get isNotEmpty => length != 0;
 
-  /// Returns an [TreeIterator] that iterates over this tree.
+  /// Returns a [TreeIterator] that iterates over this tree.
   @override
   TreeIterator<V> get iterator;
 
-  /// Returns an [TreeIterator] that iterates over this tree, in
+  /// Returns a [TreeIterator] that iterates over this tree, in
   /// reverse.
   TreeIterator<V> get reverseIterator;
 

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -440,7 +440,7 @@ class AvlTreeSet<V> extends TreeSet<V> {
     ++_modCount;
     --_length;
 
-    // note: if you read wikipedia, it _states remove the node if its a leaf,
+    // note: if you read wikipedia, it states remove the node if its a leaf,
     // otherwise, replace it with its predecessor or successor. We're not.
     if (!node.hasRight || !node.right.hasLeft) {
       // simple solutions

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 repository: https://github.com/google/quiver-dart
-version: 3.1.0
+version: 3.2.0-dev
 
 # When updating SDK lower bound, also update .github/workflows/dart.yml to test
 # against the new lower bound.


### PR DESCRIPTION
I'm planning to deprecate `BidirectionalIterator`, hopefully to remove it in Dart 3.0.

The `TreeSet` exposes a bidirectional iterator. 
By changing it to making the `_AvlTreeIterator` public as `TreeIterator`, the API no longer depends on `BidirectionalIterator`.

The `_AvlTreeIterator` exposed some of its state as public getters. I have made some of them private, and kept others as public. 
If they weren't intended to be public, we can make them all private.

Code which uses `.iterator` with inference will now infer `TreeIterator` instead, with (at least) the same API.
Code which uses `BidirectionalIterator` will still work, because the `TreeIterator` still implements the interface, but will get their own deprecation warnings so they can change it to `TreeIterator`.

In the long run, I'd recommend just implementing `Iterator`, and let `TreeIterator` define the `movePrevious` itself.