### PR TITLE
docs: rename IsochronousStream to Metronome

### DIFF
--- a/lib/src/async/metronome.dart
+++ b/lib/src/async/metronome.dart
@@ -41,8 +41,8 @@ import 'package:quiver/time.dart';
 ///
 /// Example anchored in the future (now = 2014-05-05 20:06:00.123)
 ///
-///     new IsochronousStream.periodic(aMillisecond * 100,
-///         anchorMs: DateTime.parse("2014-05-05 21:07:00"))
+///     new Metronome.periodic(aMillisecond * 100,
+///             anchor: DateTime.parse("2014-05-05 21:07:00"))
 ///         .listen(print);
 ///
 ///     2014-05-04 20:06:00.223


### PR DESCRIPTION
When reading the docs for the `Metronome` class I noticed that there is a reference to a `IsochronousStream` class that doesn't exist in the quiver library. I think should be renamed to `Metronome`. Also, the parameter is now `anchor` rather than `anchorMs` 😁.