### PR TITLE
Stop implementing deprecated `BidirectionalIterator`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
   * Deprecate `Optional`. With the introduction of non-null by default in Dart
     SDK 2.12, existing users should migrate to non-nullable types. This type
     will be removed in Quiver 4.0.0.
-  * Expose `TreeIterator` for iterating `TreeSet` instead of using
-    `BidirectionalIterator`.
+  * Make `TreeIterator` not implement deprecated `BidirectionalIterator`.
+    The `movePrevious` method still exists on `TreeIterator`.
   * Require Dart 2.17
 
 #### 3.1.0 - 2022-05-03

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -891,10 +891,7 @@ AvlNode<V>? debugGetNode<V>(AvlTreeSet<V> treeset, V object) {
 /// [TreeSet.fromIterator]). When using fromIterator, the initial anchor point
 /// is included in the first movement (either [moveNext] or [movePrevious]) but
 /// can optionally be excluded in the constructor.
-class TreeIterator<V>
-    implements
-        // ignore: deprecated_member_use
-        BidirectionalIterator<V> {
+class TreeIterator<V> implements Iterator<V> {
   TreeIterator._(this.tree,
       {this.reversed = false, this.inclusive = true, V? anchorObject})
       : _anchorObject = anchorObject,

--- a/lib/src/collection/treeset.dart
+++ b/lib/src/collection/treeset.dart
@@ -967,7 +967,6 @@ class TreeIterator<V> implements Iterator<V> {
   @override
   bool moveNext() => _moveNext();
 
-  @override
   bool movePrevious() => _movePrevious();
 
   bool _moveNextNormal() {


### PR DESCRIPTION
The `TreeIterator` implemented `BidirectionalIterator`, which is deprecated and will go away in Dart 3.0.

This changes it to just implement `Iterarator`, and have its own `movePrevious`.

This could be a breaking change, but it does not appear that anyone ever casts the `TreeIterator` to `BidirectionalIterator` (because they might as well just keep the `TreeIterator` type, and there is no helper function anywhere in the world which expects just a `BidirectionalIterator` that you can pass the iterator to).
