### PR TITLE
Deprecate Optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.2.2-dev
 
 - Fix a number of doc comment issues.
+- Re-deprecate `Optional` but provide more nuance to the documentation.
 
 ## 3.2.1 - 2022-12-20
 

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -24,10 +24,11 @@ import 'dart:collection';
 ///
 /// With the introduction of non-null by default in Dart SDK 2.12, developers
 /// should avoid adding more uses of this type. Existing users should migrate
-/// away from the `Optional` type to types marked nullable: `T?`. This type
-/// will be removed in Quiver 4.0.0.
-// TODO(kevmoo): re-deprecate this once usage is removed from Flutter plugins
-//@Deprecated('Migrate to a non-nullable type. Will be removed in 4.0.0')
+/// away from the `Optional` type to types marked nullable: `T?`.
+/// 
+/// There are a small number of cases where this is the appropriate abstraction 
+/// and we therefore do not intend on removing this type.
+@Deprecated('Generally, migrate to a nullable type.')
 class Optional<T> extends IterableBase<T> {
   /// Constructs an empty Optional.
   const Optional.absent() : _value = null;

--- a/lib/src/core/optional.dart
+++ b/lib/src/core/optional.dart
@@ -25,8 +25,8 @@ import 'dart:collection';
 /// With the introduction of non-null by default in Dart SDK 2.12, developers
 /// should avoid adding more uses of this type. Existing users should migrate
 /// away from the `Optional` type to types marked nullable: `T?`.
-/// 
-/// There are a small number of cases where this is the appropriate abstraction 
+///
+/// There are a small number of cases where this is the appropriate abstraction
 /// and we therefore do not intend on removing this type.
 @Deprecated('Generally, migrate to a nullable type.')
 class Optional<T> extends IterableBase<T> {


### PR DESCRIPTION
We do not intend on fully removing this type given the large amount of internal code that depends on it. Also this abstraction is useful in rare instances for the null-safety migration. To discourage adoption however, we will deprecate it and update the documentation.