### PR TITLE
Drop deprecated lint: package_api_docs

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,7 +15,6 @@ linter:
     - directives_ordering
     - flutter_style_todos
     - no_adjacent_strings_in_list
-    - package_api_docs
     - prefer_asserts_in_initializer_lists
     - prefer_const_constructors
     - prefer_const_constructors_in_immutables


### PR DESCRIPTION
This PR contains changes created by the blast repo tool.

- `drop-lint`