### PR TITLE
Deprecate hash functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.2.3-wip
+
+- Deprecate all `hash` functions. Use functions in `Object` instead.
+
 ## 3.2.2
 
 - Fix a number of doc comment issues.

--- a/lib/src/core/hash.dart
+++ b/lib/src/core/hash.dart
@@ -13,31 +13,17 @@
 // limitations under the License.
 
 /// Generates a hash code for multiple [objects].
-int hashObjects(Iterable objects) =>
-    _finish(objects.fold(0, (h, i) => _combine(h, i.hashCode)));
+@Deprecated('Use Object.hashAll instead')
+int hashObjects(Iterable objects) => Object.hashAll(objects);
 
 /// Generates a hash code for two objects.
-int hash2(a, b) => _finish(_combine(_combine(0, a.hashCode), b.hashCode));
+@Deprecated('Use Object.hash instead')
+int hash2(a, b) => Object.hash(a, b);
 
 /// Generates a hash code for three objects.
-int hash3(a, b, c) => _finish(
-    _combine(_combine(_combine(0, a.hashCode), b.hashCode), c.hashCode));
+@Deprecated('Use Object.hash instead')
+int hash3(a, b, c) => Object.hash(a, b, c);
 
 /// Generates a hash code for four objects.
-int hash4(a, b, c, d) => _finish(_combine(
-    _combine(_combine(_combine(0, a.hashCode), b.hashCode), c.hashCode),
-    d.hashCode));
-
-// Jenkins hash functions
-
-int _combine(int hash, int value) {
-  hash = 0x1fffffff & (hash + value);
-  hash = 0x1fffffff & (hash + ((0x0007ffff & hash) << 10));
-  return hash ^ (hash >> 6);
-}
-
-int _finish(int hash) {
-  hash = 0x1fffffff & (hash + ((0x03ffffff & hash) << 3));
-  hash = hash ^ (hash >> 11);
-  return 0x1fffffff & (hash + ((0x00003fff & hash) << 15));
-}
+@Deprecated('Use Object.hash instead')
+int hash4(a, b, c, d) => Object.hash(a, b, c, d);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: >-
   Quiver is a set of utility libraries for Dart that makes using many Dart
   libraries easier and more convenient, or adds additional functionality.
 repository: https://github.com/google/quiver-dart
-version: 3.2.2
+version: 3.2.3-wip
 
 # When updating SDK lower bound, also update .github/workflows/dart.yml to test
 # against the new lower bound.

--- a/test/core/hash_test.dart
+++ b/test/core/hash_test.dart
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// ignore_for_file: deprecated_member_use_from_same_package
+
 library quiver.core.hash_test;
 
 import 'package:quiver/src/core/hash.dart';


### PR DESCRIPTION
Folks should use Object.hash bits instead
Replaced impl w/ Object.hash bits
